### PR TITLE
move id setting in unmarshaller

### DIFF
--- a/src/main/java/org/jongo/MongoCollection.java
+++ b/src/main/java/org/jongo/MongoCollection.java
@@ -16,16 +16,16 @@
 
 package org.jongo;
 
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
-import com.mongodb.WriteConcern;
-import com.mongodb.WriteResult;
 import org.bson.types.ObjectId;
 import org.jongo.marshall.Marshaller;
 import org.jongo.marshall.Unmarshaller;
 import org.jongo.query.Query;
 import org.jongo.query.QueryFactory;
 
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.WriteConcern;
+import com.mongodb.WriteResult;
 
 public final class MongoCollection {
 
@@ -41,6 +41,7 @@ public final class MongoCollection {
         this.queryFactory = new QueryFactory(marshaller);
     }
 
+    public static final String MONGO_DOCUMENT_ID_NAME = "_id";
     private static final Object[] NO_PARAMETERS = {};
 
     public FindOne findOne(ObjectId id) {
@@ -96,11 +97,11 @@ public final class MongoCollection {
     }
 
     public WriteResult save(Object document) {
-        return new Save(collection, marshaller, document).execute();
+        return new Save(collection, marshaller, unmarshaller, document).execute();
     }
 
     public WriteResult save(Object document, WriteConcern concern) {
-        return new Save(collection, marshaller, document).concern(concern).execute();
+        return new Save(collection, marshaller, unmarshaller, document).concern(concern).execute();
     }
 
     public WriteResult insert(String query) {
@@ -113,7 +114,7 @@ public final class MongoCollection {
     }
 
     public WriteResult remove(ObjectId id) {
-        return remove("{_id:#}", id);
+        return remove("{" + MONGO_DOCUMENT_ID_NAME + ":#}", id);
     }
 
     public WriteResult remove(String query) {

--- a/src/main/java/org/jongo/Save.java
+++ b/src/main/java/org/jongo/Save.java
@@ -16,27 +16,28 @@
 
 package org.jongo;
 
+import static org.jongo.MongoCollection.MONGO_DOCUMENT_ID_NAME;
+
+import org.jongo.marshall.Marshaller;
+import org.jongo.marshall.Unmarshaller;
+
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteResult;
 import com.mongodb.util.JSON;
-import org.bson.types.ObjectId;
-import org.jongo.marshall.Marshaller;
-
-import java.lang.reflect.Field;
 
 class Save {
 
-    private static final String MONGO_DOCUMENT_ID_NAME = "_id";
-
     private final Marshaller marshaller;
+    private final Unmarshaller unmarshaller;
     private final DBCollection collection;
     private final Object document;
     private WriteConcern concern;
 
-    Save(DBCollection collection, Marshaller marshaller, Object document) {
+    Save(DBCollection collection, Marshaller marshaller, Unmarshaller unmarshaller, Object document) {
         this.marshaller = marshaller;
+        this.unmarshaller = unmarshaller;
         this.collection = collection;
         this.document = document;
     }
@@ -53,7 +54,7 @@ class Save {
         WriteResult writeResult = collection.save(dbObject, determineWriteConcern());
 
         String id = dbObject.get(MONGO_DOCUMENT_ID_NAME).toString();
-        setDocumentGeneratedId(id);
+        unmarshaller.setDocumentGeneratedId(document, id);
 
         return writeResult;
     }
@@ -67,28 +68,6 @@ class Save {
         }
     }
 
-    private void setDocumentGeneratedId(String id) {
-        Class<?> clazz = document.getClass();
-        do {
-            findDocumentGeneratedId(id, clazz);
-            clazz = clazz.getSuperclass();
-        } while (!clazz.equals(Object.class));
-    }
-
-    private void findDocumentGeneratedId(String id, Class<?> clazz) {
-        for (Field field : clazz.getDeclaredFields()) {
-            if (field.getType().equals(ObjectId.class)) {
-                field.setAccessible(true);
-                try {
-                    field.set(document, new ObjectId(id));
-                    break;
-                } catch (IllegalAccessException e) {
-                    throw new RuntimeException("Unable to set objectid on class: " + clazz, e);
-                }
-            }
-        }
-    }
-
     private WriteConcern determineWriteConcern() {
         return concern == null ? collection.getWriteConcern() : concern;
     }
@@ -97,8 +76,7 @@ class Save {
         try {
             return ((DBObject) JSON.parse(json));
         } catch (Exception e) {
-            String message = String.format("Unable to save document, " +
-                    "json returned by marshaller cannot be converted into a DBObject: '%s'", json);
+            String message = String.format("Unable to save document, " + "json returned by marshaller cannot be converted into a DBObject: '%s'", json);
             throw new IllegalArgumentException(message, e);
         }
     }

--- a/src/main/java/org/jongo/marshall/Unmarshaller.java
+++ b/src/main/java/org/jongo/marshall/Unmarshaller.java
@@ -19,4 +19,6 @@ package org.jongo.marshall;
 public interface Unmarshaller {
 
     <T> T unmarshall(String json, Class<T> clazz) throws MarshallingException;
+
+    void setDocumentGeneratedId(Object document, String id);
 }

--- a/src/test/java/org/jongo/model/LinkedFriend.java
+++ b/src/test/java/org/jongo/model/LinkedFriend.java
@@ -1,0 +1,15 @@
+package org.jongo.model;
+
+import org.bson.types.ObjectId;
+
+public class LinkedFriend extends Friend {
+    ObjectId friendRelationId;
+
+    public LinkedFriend(ObjectId friendRelationId) {
+        this.friendRelationId = friendRelationId;
+    }
+
+    public ObjectId getRelationId() {
+        return friendRelationId;
+    }
+}


### PR DESCRIPTION
Instead of using JsonProperty directly into the Save class, it has been moved.

Unmarshaller.setDocumentGeneratedId() method is implemented by JacksonProvider in our case.
JacksonProvider seems to be a better candidate to search within a class for an _id attribute (named so or annotated with JsonProperty).

In the case of a redefinition of the Unmarshalling strategy, one must specify how to retrieve the ObjectId seted by Mongo.
