### PR TITLE
ensureIndex() as in Mongo shell

### DIFF
--- a/src/main/java/org/jongo/MongoCollection.java
+++ b/src/main/java/org/jongo/MongoCollection.java
@@ -139,15 +139,13 @@ public final class MongoCollection {
     public void drop() {
         collection.drop();
     }
+    
+    public void ensureIndex(String keys) {
+    	collection.ensureIndex(createQuery(keys).toDBObject());
+    }
 
-    public void ensureIndex(String index) {
-    	if (index.contains("},")) {
-    		String keys = index.substring(0, index.indexOf("},")+1);
-    		String options = index.substring(index.indexOf("},")+2);
-    		collection.ensureIndex(createQuery(keys).toDBObject(), createQuery(options).toDBObject());
-    	} else {
-            collection.ensureIndex(createQuery(index).toDBObject());
-    	}
+    public void ensureIndex(String keys, String options) {
+    	collection.ensureIndex(createQuery(keys).toDBObject(), createQuery(options).toDBObject());
     }
     
     public void dropIndex(String keys) {

--- a/src/test/java/org/jongo/MongoCollectionTest.java
+++ b/src/test/java/org/jongo/MongoCollectionTest.java
@@ -96,7 +96,7 @@ public class MongoCollectionTest extends JongoTestCase {
     
     @Test(expected=DuplicateKey.class)
     public void createUniqueIndex() {
-    	mongoCollection.ensureIndex("{name: 1}, {unique: true}");
+    	mongoCollection.ensureIndex("{name: 1}", "{unique: true}");
     	mongoCollection.save(new Friend("John"), WriteConcern.SAFE);
         mongoCollection.save(new Friend("John"), WriteConcern.SAFE);
     }


### PR DESCRIPTION
Added the ability to ensure an index with index creation options, as in Mongo shell. Also added missing dropIndex(keys) and dropIndexes() methods.
