### PR TITLE
Fix test case connection leak

### DIFF
--- a/src/test/java/org/jongo/util/JongoTestCase.java
+++ b/src/test/java/org/jongo/util/JongoTestCase.java
@@ -31,7 +31,8 @@ public abstract class JongoTestCase {
     public static final String MONGOHQ_FLAG = "jongo.mongohq.uri";
 
     private Jongo jongo;
-
+    private static Mongo mongo;
+    
     public JongoTestCase() {
         this.jongo = new Jongo(findDatabase(), new JsonProvider());
     }
@@ -76,7 +77,10 @@ public abstract class JongoTestCase {
     }
 
     private static DB getLocalDB() throws UnknownHostException {
-        return new Mongo("127.0.0.1").getDB("jongo");
+    	if(mongo == null) {
+    		mongo = new Mongo("127.0.0.1");
+    	}
+    	return mongo.getDB("jongo");
     }
 
     public void prepareMarshallingStrategy(Provider provider) {


### PR DESCRIPTION
Each JongoTestCase instance created a new local Mongo connection pool, so eventually if you added too many test cases then you would hit the mongod process connection limit (on OS X the default limit works out to only about 200 connections).  This update changes the test code to use a single Mongo connection pool for all tests, so Mongo can do its normal connection sharing.
