### PR TITLE
Extract @ObjectId from @Id

### DIFF
--- a/src/main/java/org/jongo/marshall/jackson/JacksonIdFieldSelector.java
+++ b/src/main/java/org/jongo/marshall/jackson/JacksonIdFieldSelector.java
@@ -17,9 +17,8 @@
 package org.jongo.marshall.jackson;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.bson.types.ObjectId;
 import org.jongo.ReflectiveObjectIdUpdater;
-import org.jongo.marshall.jackson.id.Id;
+import org.jongo.marshall.jackson.oid.Id;
 
 import java.lang.reflect.Field;
 

--- a/src/main/java/org/jongo/marshall/jackson/oid/Id.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/Id.java
@@ -14,25 +14,18 @@
  * limitations under the License.
  */
 
-package org.jongo.marshall.jackson.id;
+package org.jongo.marshall.jackson.oid;
 
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.lang.annotation.Retention;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
 @JacksonAnnotationsInside
 
-@JsonInclude(NON_NULL)
 @JsonProperty("_id")
-@JsonSerialize(using = ObjectIdSerializer.class)
-@JsonDeserialize(using = ObjectIdDeserializer.class)
 public @interface Id {
 }

--- a/src/main/java/org/jongo/marshall/jackson/oid/ObjectId.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/ObjectId.java
@@ -14,19 +14,23 @@
  * limitations under the License.
  */
 
-package org.jongo.marshall.jackson.id;
+package org.jongo.marshall.jackson.oid;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import org.bson.types.ObjectId;
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-import java.io.IOException;
+import java.lang.annotation.Retention;
 
-public class ObjectIdSerializer extends JsonSerializer<String> {
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-    @Override
-    public void serialize(String value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-        jgen.writeObject(new ObjectId(value));
-    }
+@Retention(RUNTIME)
+@JacksonAnnotationsInside
+
+@JsonInclude(NON_NULL)
+@JsonSerialize(using = ObjectIdSerializer.class)
+@JsonDeserialize(using = ObjectIdDeserializer.class)
+public @interface ObjectId {
 }

--- a/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdDeserializer.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdDeserializer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.jongo.marshall.jackson.id;
+package org.jongo.marshall.jackson.oid;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;

--- a/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdSerializer.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2011 Benoit GUEROUT <bguerout at gmail dot com> and Yves AMSELLEM <amsellem dot yves at gmail dot com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jongo.marshall.jackson.oid;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.bson.types.ObjectId;
+
+import java.io.IOException;
+
+public class ObjectIdSerializer extends JsonSerializer<String> {
+
+    @Override
+    public void serialize(String value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        jgen.writeObject(new ObjectId(value));
+    }
+}

--- a/src/test/java/org/jongo/FindTest.java
+++ b/src/test/java/org/jongo/FindTest.java
@@ -18,7 +18,7 @@ package org.jongo;
 
 import org.bson.types.ObjectId;
 import org.jongo.marshall.MarshallingException;
-import org.jongo.marshall.jackson.id.Id;
+import org.jongo.marshall.jackson.oid.Id;
 import org.jongo.model.Coordinate;
 import org.jongo.model.Friend;
 import org.jongo.util.ErrorObject;
@@ -148,6 +148,7 @@ public class FindTest extends JongoTestCase {
     private static class ExposableFriend {
 
         @Id
+        @org.jongo.marshall.jackson.oid.ObjectId
         private String id;
         private String name;
 

--- a/src/test/java/org/jongo/ReflectiveObjectIdUpdaterTest.java
+++ b/src/test/java/org/jongo/ReflectiveObjectIdUpdaterTest.java
@@ -18,7 +18,7 @@ package org.jongo;
 
 import org.bson.types.ObjectId;
 import org.jongo.marshall.jackson.JacksonIdFieldSelector;
-import org.jongo.marshall.jackson.id.Id;
+import org.jongo.marshall.jackson.oid.Id;
 import org.jongo.model.Coordinate;
 import org.jongo.model.ExternalFriend;
 import org.jongo.model.Friend;

--- a/src/test/java/org/jongo/marshall/jackson/JacksonIdFieldSelectorTest.java
+++ b/src/test/java/org/jongo/marshall/jackson/JacksonIdFieldSelectorTest.java
@@ -19,7 +19,7 @@ package org.jongo.marshall.jackson;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.bson.types.ObjectId;
 import org.jongo.ReflectiveObjectIdUpdater;
-import org.jongo.marshall.jackson.id.Id;
+import org.jongo.marshall.jackson.oid.Id;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/org/jongo/model/Friend.java
+++ b/src/test/java/org/jongo/model/Friend.java
@@ -16,12 +16,12 @@
 
 package org.jongo.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.bson.types.ObjectId;
+import org.jongo.marshall.jackson.oid.Id;
 
 public class Friend {
 
-    @JsonProperty("_id")
+    @Id
     private ObjectId id;
     private String name;
     private String address;


### PR DESCRIPTION
@Id seems to bring confusion; many have tried to use it on an Integer, as if it was an alias for @JsonProperty("_id"). And, because it brings a de/serializer, it can only be used on String.

To avoid such problems, this pull-request extract the de/serializer from @Id into a new annotation, @ObjectId.

This offers two advantages:
— @Id can now be used everywhere as an alias for @JsonProperty("_id")
— @ObjectId is dedicated to String and can be used on document id and document embedded ObjectId (links to other documents)

@Id package have been renamed in order to advise .3 users.

The documentation can be edited the following way:

``` java
// generate it!
public class Friend {
    @Id
    private Integer key;
}
// equivalent to
public class Friend {
    @JsonProperty("_id")
    private Integer key;
}
// equivalent to
public class Friend {
    private Integer _id;
}
```

And completed with:

``` java
// auto generate
public class Friend {
    @ObjectId
    private String _id;
}
// equivalent to
public class Friend {
    @Id
    @ObjectId
    private String key;
}
// equivalent to
public class Friend {
    private ObjectId _id;
}
```
