### PR TITLE
Issue #130: compatibility issue with GridFS.

### DIFF
--- a/src/main/java/org/jongo/RawResultHandler.java
+++ b/src/main/java/org/jongo/RawResultHandler.java
@@ -1,0 +1,19 @@
+package org.jongo;
+
+import com.mongodb.DBObject;
+
+public class RawResultHandler<T extends DBObject> implements ResultHandler<T> {
+    public static <T extends DBObject> RawResultHandler<T> asRaw(Class<T> clazz) {
+        return new RawResultHandler<T>(clazz);
+    }
+
+    private final Class<T> clazz;
+
+    public RawResultHandler(Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    public T map(DBObject result) {
+        return clazz.cast(result);
+    }
+}

--- a/src/main/java/org/jongo/bson/BsonDBDecoder.java
+++ b/src/main/java/org/jongo/bson/BsonDBDecoder.java
@@ -17,6 +17,7 @@
 package org.jongo.bson;
 
 import com.mongodb.*;
+import com.mongodb.gridfs.GridFSDBFile;
 import org.bson.LazyBSONCallback;
 
 import java.util.Iterator;
@@ -42,14 +43,20 @@ public class BsonDBDecoder extends LazyDBDecoder implements DBDecoder {
     private static class BsonDBCallback extends LazyDBCallback {
 
         private final DB db;
+        private final DBCollection collection;
 
         public BsonDBCallback(DBCollection collection) {
             super(collection);
+            this.collection = collection;
             this.db = collection == null ? null : collection.getDB();
         }
 
         @Override
         public Object createObject(byte[] data, int offset) {
+            if (GridFSDBFile.class.equals(collection.getObjectClass())) {
+                return DefaultDBDecoder.FACTORY.create().decode(data, collection);
+            }
+
             DBObject dbo = new RelaxedLazyDBObject(data, new LazyBSONCallback());
 
             Iterator it = dbo.keySet().iterator();

--- a/src/test/java/org/jongo/gridfs/GridFsTest.java
+++ b/src/test/java/org/jongo/gridfs/GridFsTest.java
@@ -1,0 +1,75 @@
+package org.jongo.gridfs;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.gridfs.GridFS;
+import com.mongodb.gridfs.GridFSDBFile;
+import com.mongodb.gridfs.GridFSInputFile;
+import org.jongo.RawResultHandler;
+import org.jongo.util.JongoTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.jongo.RawResultHandler.asRaw;
+
+public class GridFsTest extends JongoTestCase {
+
+    GridFS gridFS;
+
+    @Before
+    public void setUp() throws Exception {
+        gridFS = new GridFS(getDatabase());
+        insertTestFileInGridFS();
+    }
+
+    @Test
+    public void shouldAllowDualAccessToFilesCollection() throws Exception {
+        queryWithJongoAndMapToCustomClass();
+        queryWithJongoAndMapToGridFSDBFile();
+        queryWithGridFS();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        dropGridFsCollections();
+    }
+
+    private void insertTestFileInGridFS() {
+        GridFSInputFile gridFile = gridFS.createFile(new byte[]{
+                (byte) 0xCA,
+                (byte) 0xFE,
+                (byte) 0xBA,
+                (byte) 0xBE});
+        gridFile.setFilename("test.txt");
+        gridFile.save();
+    }
+
+    private void queryWithJongoAndMapToCustomClass() {
+        CustomFileDescriptor descriptor = getJongo().getCollection("fs.files")
+                .findOne()
+                .as(CustomFileDescriptor.class);
+        assertThat(descriptor.filename).isEqualTo("test.txt");
+    }
+
+    private void queryWithJongoAndMapToGridFSDBFile() {
+        GridFSDBFile gridFile = getJongo().getCollection("fs.files")
+                .findOne()
+                .map(asRaw(GridFSDBFile.class));
+        assertThat(gridFile.getFilename()).isEqualTo("test.txt");
+    }
+
+    private void queryWithGridFS() {
+        GridFSDBFile gridFile = gridFS.findOne(new BasicDBObject());
+        assertThat(gridFile.getFilename()).isEqualTo("test.txt");
+    }
+
+    private void dropGridFsCollections() throws Exception {
+        getDatabase().getCollection("fs.files").drop();
+        getDatabase().getCollection("fs.chunks").drop();
+    }
+
+    static class CustomFileDescriptor {
+        String filename;
+    }
+}


### PR DESCRIPTION
In `BsonDBDecoder#createObject`, fallback to default decoding if we detect that the collection is GridFS-related. The returned object is a `GridFSDBFile`, not a `RelaxedLazyDBObject`.

Note that this defeats the performance optimization that `RelaxedLazyDBObject` was trying to achieve: if the user later maps the results to another class, the decoding occurs twice (bytes -> `RelaxedLazyDBObject` -> custom class). I think this is acceptable in that case.

Also handled the case where the user doesn't want to map to a custom class, but get `GridFSDBFile`s directly. Since we know that the decoder already returns objects of the right type, the handler only needs to cast. Added `RawResultHandler` to that purpose:

``` java
import static org.jongo.RawResultHandler.asRaw;
GridFSDBFile f = jongo.getCollection("fs.files")
                      .findOne()
                      .map(asRaw(GridFSDBFile.class));
```
