### PR TITLE
README: link to java docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ Queries can be written as String, results can be unmarshalled as any Java object
 
 Documentation available at <a href="http://www.jongo.org/">jongo.org</a>
 
-
+Java docs at https://jongo.ci.cloudbees.com/job/jongo-ci/site/apidocs/index.html
 


### PR DESCRIPTION
Added a link to the Java docs, per https://github.com/bguerout/jongo/issues/160
