### PR TITLE
fix: call setAccessible when setting String id

### DIFF
--- a/src/main/java/org/jongo/ReflectiveObjectIdUpdater.java
+++ b/src/main/java/org/jongo/ReflectiveObjectIdUpdater.java
@@ -66,6 +66,7 @@ public class ReflectiveObjectIdUpdater implements ObjectIdUpdater {
                 field.setAccessible(true);
                 field.set(target, id);
             } else if (field.getType().equals(String.class)) {
+                field.setAccessible(true);
                 field.set(target, id.toString());
             }
         } catch (IllegalAccessException e) {


### PR DESCRIPTION
setAccessible is called only when field is an ObjectId, I see no reason why it shouldn't be called if the field is a String. 
