### PR TITLE
Fix ObjectId string deserializer

### DIFF
--- a/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdDeserializer.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdDeserializer.java
@@ -18,6 +18,7 @@ package org.jongo.marshall.jackson.oid;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -34,6 +35,8 @@ public class ObjectIdDeserializer extends JsonDeserializer<String> {
         JsonNode oid = ((JsonNode) treeNode).get(MONGO_QUERY_OID);
         if (oid != null)
             return oid.asText();
+        else if (JsonToken.VALUE_STRING == treeNode.asToken()) {
+            return ((TextNode) treeNode).asText();
         else
             return treeNode.toString();
     }

--- a/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdDeserializer.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdDeserializer.java
@@ -35,7 +35,7 @@ public class ObjectIdDeserializer extends JsonDeserializer<String> {
         JsonNode oid = ((JsonNode) treeNode).get(MONGO_QUERY_OID);
         if (oid != null)
             return oid.asText();
-        else if (JsonToken.VALUE_STRING == treeNode.asToken()) {
+        else if (JsonToken.VALUE_STRING == treeNode.asToken())
             return ((TextNode) treeNode).asText();
         else
             return treeNode.toString();


### PR DESCRIPTION
I encounter a problem when define the @ObjectId annotation on a String property as follow:

@ObjectId
@org.jongo.marshall.jackson.oid.Id
private String id;

I use Jackson to convert the same json object twice:
1) convert java object to/from mongoDB 
2) convert java object to/from spring REST controller (as java server api)

The ObjectIdDeserializer adding extra inverted commas (") when converting the text from json to java object using spring REST Controller.
for example the following json object:
{
    "id" : "52d25f8f6e5c6d7a25eea8b5"
} 
is converted to java object with double inverted commas as follow:
private String id = ""52d25f8f6e5c6d7a25eea8b5""

the code I added is fix this issue using asText() function instead of toString() function.