### PR TITLE
Refactor Aggregate class to use collection.aggregate(...) #125

### DIFF
--- a/src/main/java/org/jongo/MongoCollection.java
+++ b/src/main/java/org/jongo/MongoCollection.java
@@ -16,7 +16,11 @@
 
 package org.jongo;
 
-import com.mongodb.*;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.WriteResult;
 import org.bson.types.ObjectId;
 import org.jongo.query.Query;
 
@@ -169,7 +173,7 @@ public class MongoCollection {
     }
 
     public Aggregate aggregate(String pipelineOperator, Object... parameters) {
-        return new Aggregate(collection.getDB(), collection.getName(), mapper.getUnmarshaller(), mapper.getQueryFactory()).and(pipelineOperator, parameters);
+        return new Aggregate(collection, mapper.getUnmarshaller(), mapper.getQueryFactory()).and(pipelineOperator, parameters);
     }
 
     public void drop() {

--- a/src/test/java/org/jongo/AggregateTest.java
+++ b/src/test/java/org/jongo/AggregateTest.java
@@ -104,7 +104,7 @@ public class AggregateTest extends JongoTestCase {
             collection.aggregate("{$invalid:{}}").as(Article.class);
             fail();
         } catch (Exception e) {
-            assertThat(e.getClass().toString()).contains("CommandFailure");
+            assertThat(e.getMessage()).contains("result undefined");
         }
     }
 


### PR DESCRIPTION
Use dbCollection.aggregate instead of db.runCommand for running aggregation framework command.

It was tested agains mongodb 2.6.0
