### PR TITLE
Fix BsonQueryFactory so that it can update polymorphic fields

### DIFF
--- a/src/test/java/org/jongo/NestedPolymorphismTest.java
+++ b/src/test/java/org/jongo/NestedPolymorphismTest.java
@@ -1,0 +1,115 @@
+package org.jongo;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.bson.types.ObjectId;
+import org.jongo.marshall.jackson.oid.Id;
+import org.jongo.util.JongoTestCase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NestedPolymorphismTest extends JongoTestCase {
+
+    private MongoCollection collection;
+
+    @Before
+    public void setUp() throws Exception {
+        collection = createEmptyCollection("owners");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        dropCollection("owners");
+    }
+
+    @Test
+    public void testCanSaveAndReadNestedPolymorphicField() throws Exception {
+        Owner owner = new Owner();
+        owner.setPet(new Cat("Sylvester", 42));
+
+        collection.save(owner);
+
+        Owner owner2 = collection.findOne(owner.getId()).as(Owner.class);
+        assertThat(owner2.getPet()).isInstanceOf(Cat.class);
+
+        Cat cat = (Cat)owner2.getPet();
+        assertThat(cat.getName()).isEqualTo("Sylvester");
+        assertThat(cat.getMiceEaten()).isEqualTo(42);
+    }
+
+    @Test
+    public void testCanUpdatePolymorphicField() throws Exception {
+
+        Owner owner = new Owner();
+        owner.setPet(new Cat("Sylvester", 42));
+
+        collection.save(owner);
+
+        collection.update("{_id: #}", owner.getId()).with("{$set: {pet: #}}", new Cat("Tom", 0));
+
+        Owner owner2 = collection.findOne(owner.getId()).as(Owner.class);
+        Cat cat = (Cat)owner2.getPet();
+        assertThat(cat.getName()).isEqualTo("Tom");
+        assertThat(cat.getMiceEaten()).isEqualTo(0);
+
+    }
+
+    public static class Owner {
+        @Id
+        private ObjectId id;
+
+        private Pet pet;
+
+        public ObjectId getId() {
+            return id;
+        }
+
+        public Pet getPet() {
+            return pet;
+        }
+
+        public void setPet(Pet pet) {
+            this.pet = pet;
+        }
+    }
+
+    /**
+     * A Pet is serialized with a "type" attribute, which is more robust
+     * and cross-language than the default @class attribute
+     */
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({ @JsonSubTypes.Type(name="cat", value = Cat.class) })
+    public static class Pet {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class Cat extends Pet {
+        private int miceEaten;
+
+        public Cat() {}
+
+        public Cat(String name, int mice) {
+            setName(name);
+            setMiceEaten(mice);
+        }
+        public int getMiceEaten() {
+            return miceEaten;
+        }
+
+        public void setMiceEaten(int miceEaten) {
+            this.miceEaten = miceEaten;
+        }
+    }
+}


### PR DESCRIPTION
In `BsonQueryFactory.marshallDocument()`, wrapping the parameter in an untyped object causes problems when updating polymorphic fields: the additional JSON attribute that is added to identify the actual subclass of the instance is lost.

This is caused by the fact that during serialization, Jackson only considers annotations on a class only for the root object (the one that is being serialized) or class members.

As the wrapping is meant to handle the (rare?) case where objects are serialized as primitive values, we do the wrapping only if the initial serialization returned an object with no properties.
