### PR TITLE
Fix '#' substitution in array values

### DIFF
--- a/src/main/java/org/jongo/query/BsonQueryFactory.java
+++ b/src/main/java/org/jongo/query/BsonQueryFactory.java
@@ -171,11 +171,25 @@ public class BsonQueryFactory implements QueryFactory {
             char c = query.charAt(pos);
             if (c == ':') {
                 return true;
-            } else if (c == ',' || c == '{' || c == '.') {
+            } else if (c == '{' || c == '.') {
                 return false;
+            } else if (c == ',') {
+                return !isPropertyName(query, pos-1);
             }
         }
         return true;
+    }
+
+    private boolean isPropertyName(String query, int tokenIndex) {
+        for (int pos = tokenIndex; pos >= 0; pos--) {
+            char c = query.charAt(pos);
+            if (c == '[') {
+                return false;
+            } else if (c == '{') {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Object marshallParameter(Object parameter) {

--- a/src/test/java/org/jongo/query/BsonQueryFactoryTest.java
+++ b/src/test/java/org/jongo/query/BsonQueryFactoryTest.java
@@ -200,6 +200,22 @@ public class BsonQueryFactoryTest {
     }
 
     @Test
+    public void shouldBindOneValueInAnArray() throws Exception {
+
+        Query query = factory.createQuery("{a: [ # ]}", "test");
+
+        assertThat(query.toDBObject()).isEqualTo(QueryBuilder.start("a").is(new String[]{"test"}).get());
+    }
+
+    @Test
+    public void shouldBindManyValuesInAnArray() throws Exception {
+
+        Query query = factory.createQuery("{a: [#, 'test2', #]}", "test1", "test3");
+
+        assertThat(query.toDBObject()).isEqualTo(QueryBuilder.start("a").is(new String[]{"test1", "test2", "test3"}).get());
+    }
+
+    @Test
     public void shouldBindANestedKeyParameter() throws Exception {
 
         Query query = factory.createQuery("{ name.#: 'John'}", "first");


### PR DESCRIPTION
Adds special handling of commas in the query parser, as they may appear both as an object property delimiter and an array member delimiter.

When encountering a comma, we check in the preceding characters what comes first : `'{'` (an object property) or `'['` (an array value)
