### PR TITLE
Removed reference to exception deprecated in 2.13 of the Java driver

### DIFF
--- a/src/test/java/org/jongo/AggregateTest.java
+++ b/src/test/java/org/jongo/AggregateTest.java
@@ -16,7 +16,7 @@
 
 package org.jongo;
 
-import com.mongodb.CommandFailureException;
+import com.mongodb.MongoCommandException;
 import org.jongo.util.JongoTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -110,7 +110,7 @@ public class AggregateTest extends JongoTestCase {
             collection.aggregate("{$invalid:{}}").as(Article.class);
             fail();
         } catch (Exception e) {
-            assertThat(CommandFailureException.class).isAssignableFrom(e.getClass());
+            assertThat(MongoCommandException.class).isAssignableFrom(e.getClass());
         }
     }
 


### PR DESCRIPTION
In AggregateTest, replaced reference to CommandFailureException, which has been deprecated, with a reference to MongoCommandException.

With this minor change, Jongo will compile and pass all tests against the 3.0.x branch of the Java driver.