### PR TITLE
A proposal for the implementation of aggregation options in Jongo.

### DIFF
--- a/src/test/java/org/jongo/AggregateTest.java
+++ b/src/test/java/org/jongo/AggregateTest.java
@@ -16,6 +16,7 @@
 
 package org.jongo;
 
+import com.mongodb.AggregationOptions;
 import com.mongodb.CommandFailureException;
 import org.jongo.util.JongoTestCase;
 import org.junit.After;
@@ -25,9 +26,14 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static junit.framework.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class AggregateTest extends JongoTestCase {
 
@@ -59,6 +65,34 @@ public class AggregateTest extends JongoTestCase {
         for (Article article : articles) {
             assertThat(article.title).isIn("Zombie Panic", "Apocalypse Zombie", "World War Z");
         }
+    }
+
+    @Test
+    public void canAggregateWithDefaultOptions() throws Exception {
+        AggregationOptions options = AggregationOptions.builder().build();
+        Iterable<Article> articles = collection.aggregate("{$match:{}}").options(options).as(Article.class);
+
+        assertThat(articles.iterator().hasNext()).isTrue();
+        for (Article article : articles) {
+            assertThat(article.title).isIn("Zombie Panic", "Apocalypse Zombie", "World War Z");
+        }
+    }
+
+    @Test
+    public void canAggregateWithOptions() throws Exception {
+
+        AggregationOptions options = spy(AggregationOptions.builder().outputMode(AggregationOptions.OutputMode.CURSOR).allowDiskUse(true).build());
+
+        Iterable<Article> articles = collection.aggregate("{$match:{}}").options(options).as(Article.class);
+
+        assertThat(articles.iterator().hasNext()).isTrue();
+        for (Article article : articles) {
+            assertThat(article.title).isIn("Zombie Panic", "Apocalypse Zombie", "World War Z");
+        }
+        verify(options, atLeastOnce()).getAllowDiskUse();
+        verify(options, atLeastOnce()).getMaxTime(any(TimeUnit.class));
+        verify(options, atLeastOnce()).getBatchSize();
+        verify(options, atLeastOnce()).getOutputMode();
     }
 
     @Test


### PR DESCRIPTION
I decided to use the existing AggregationOptions rather than duplicating its api so that the solution would
automatically accept any new options the mongo team introduces.
The testing coverage is light because I couldn't think of an effective way to check that
the options were being applied without relying heavily on the Mongo implementation itself.

After writing this I noticed this there is a related pull request @see  issue #203 