### PR TITLE
Allow all versions of the 3.x mongo-java-driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,8 @@
     </prerequisites>
 
     <properties>
-        <mongo.version>[2.13.0,3.0.0]</mongo.version>
+        <mongo.min.version>2.13.0</mongo.min.version>
+        <mongo.max.version>3.0.0</mongo.max.version>
         <jackson.version>2.4.1</jackson.version>
         <bson4jackson.version>2.4.0</bson4jackson.version>
     </properties>
@@ -84,7 +85,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>${mongo.version}</version>
+            <version>[${mongo.min.version},${mongo.max.version}]</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -263,7 +264,7 @@
                             <manifestLocation>${project.build.directory}</manifestLocation>
                             <instructions>
                                 <Import-Package>
-                                    com.mongodb.*;version="${mongo.version}",org.bson.*;version="${mongo.version}",*
+                                    com.mongodb.*;version="${mongo.min.version}",org.bson.*;version="${mongo.min.version}",*
                                 </Import-Package>
                             </instructions>
                         </configuration>


### PR DESCRIPTION
Jongo can only be used with version 3.0.0 of the mongo-java-driver's
3.x series. With this commit, we'll be able to enjoy bug fixes and
improvements that come with the java driver.