### PR TITLE
Don't use bash arrays in bourne shell script

### DIFF
--- a/src/test/sh/run-tests-against-all-driver-versions.sh
+++ b/src/test/sh/run-tests-against-all-driver-versions.sh
@@ -9,7 +9,7 @@ A_VERSION_HAS_FAILED=false
 OPTS=$*
 
 mkdir -p "$OUTPUT_DIR";
-DB_VERSIONS=( "2.6" "3.0" )
+DB_VERSIONS="2.6 3.0"
 DRIVER_VERSIONS=$(curl -so "$MONGO_ARTIFACTS_FILE" "$NEXUS_URL" &&  grep -e "version" "$MONGO_ARTIFACTS_FILE" | sed 's/<version>//g' | sed 's/<\/version>//g' | tr -s " " | sort | uniq);
 
 echo "Executing tests for mongo-java-driver[$DRIVER_VERSIONS] dependencies available on Nexus http://repository.sonatype.org"


### PR DESCRIPTION
This allows us to use the standard for loop syntax, otherwise tests
don't run against MongoDB other than 2.6.