### PR TITLE
Upgrade Jackson to 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,10 @@
     </prerequisites>
 
     <properties>
-        <mongo.min.version>2.13.0</mongo.min.version>
-        <mongo.max.version>3.0.0</mongo.max.version>
-        <jackson.version>2.4.1</jackson.version>
-        <bson4jackson.version>2.4.0</bson4jackson.version>
+        <mongo.min.version>3.0.0</mongo.min.version>
+        <mongo.max.version>3.1.0</mongo.max.version>
+        <jackson.version>2.5.1</jackson.version>
+        <bson4jackson.version>2.5.0</bson4jackson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This PR is not complete.

Changes required to support Jackson 2.5.1.  Currently, this is just the POM updates required, exposing one failing test related to `MinKey` and `MaxKey` fields.  Other than that issue, this project seems compatible with Jackson 2.5.1.