### PR TITLE
@MongoId and @MongoObjectId test coverage improvements.

### DIFF
--- a/src/main/java/org/jongo/ReflectiveObjectIdUpdater.java
+++ b/src/main/java/org/jongo/ReflectiveObjectIdUpdater.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
+@Deprecated
 public class ReflectiveObjectIdUpdater implements ObjectIdUpdater {
 
     private final Map<Class<?>, Field> fieldCache = new HashMap<Class<?>, Field>();

--- a/src/main/java/org/jongo/marshall/jackson/JacksonEngine.java
+++ b/src/main/java/org/jongo/marshall/jackson/JacksonEngine.java
@@ -23,6 +23,8 @@ import org.jongo.marshall.MarshallingException;
 import org.jongo.marshall.Unmarshaller;
 import org.jongo.marshall.jackson.configuration.Mapping;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
@@ -33,6 +35,10 @@ public class JacksonEngine implements Unmarshaller, Marshaller {
 
     public JacksonEngine(Mapping mapping) {
         this.mapping = mapping;
+    }
+    
+    public ObjectMapper getObjectMapper() {
+        return mapping.getObjectMapper();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/jongo/marshall/jackson/JacksonIdFieldSelector.java
+++ b/src/main/java/org/jongo/marshall/jackson/JacksonIdFieldSelector.java
@@ -17,6 +17,7 @@
 package org.jongo.marshall.jackson;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.bson.types.ObjectId;
 import org.jongo.ReflectiveObjectIdUpdater;
 import org.jongo.marshall.jackson.oid.Id;
@@ -25,6 +26,7 @@ import org.jongo.marshall.jackson.oid.MongoObjectId;
 
 import java.lang.reflect.Field;
 
+@Deprecated
 public class JacksonIdFieldSelector implements ReflectiveObjectIdUpdater.IdFieldSelector {
 
     public boolean isId(Field f) {

--- a/src/main/java/org/jongo/marshall/jackson/JacksonMapper.java
+++ b/src/main/java/org/jongo/marshall/jackson/JacksonMapper.java
@@ -19,7 +19,6 @@ package org.jongo.marshall.jackson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jongo.Mapper;
 import org.jongo.ObjectIdUpdater;
-import org.jongo.ReflectiveObjectIdUpdater;
 import org.jongo.marshall.Marshaller;
 import org.jongo.marshall.Unmarshaller;
 import org.jongo.marshall.jackson.configuration.AbstractMappingBuilder;
@@ -73,7 +72,7 @@ public class JacksonMapper implements Mapper {
                 queryFactory = new BsonQueryFactory(jacksonEngine);
             }
             if (objectIdUpdater == null) {
-                objectIdUpdater = new ReflectiveObjectIdUpdater(new JacksonIdFieldSelector());
+                objectIdUpdater = new JacksonObjectIdUpdater(jacksonEngine.getObjectMapper());
             }
             return new JacksonMapper(jacksonEngine, queryFactory, objectIdUpdater);
         }

--- a/src/main/java/org/jongo/marshall/jackson/JacksonObjectIdUpdater.java
+++ b/src/main/java/org/jongo/marshall/jackson/JacksonObjectIdUpdater.java
@@ -1,0 +1,108 @@
+package org.jongo.marshall.jackson; 
+
+import org.bson.types.ObjectId;
+import org.jongo.ObjectIdUpdater;
+import org.jongo.marshall.jackson.oid.Id;
+import org.jongo.marshall.jackson.oid.MongoId;
+import org.jongo.marshall.jackson.oid.MongoObjectId;
+
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.BasicBeanDescription;
+import com.fasterxml.jackson.databind.introspect.BasicClassIntrospector;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * An ObjectIdUpdater based on Jackson's view of on object.
+ * 
+ * @author Christian Trimble
+ */
+@SuppressWarnings("deprecation")
+public class JacksonObjectIdUpdater implements ObjectIdUpdater {
+
+    ObjectMapper mapper;
+    
+    public JacksonObjectIdUpdater( ObjectMapper mapper ) {
+        this.mapper = mapper;
+    }
+
+    public boolean mustGenerateObjectId(Object pojo) {
+        for( BeanPropertyDefinition def : beanDescription(pojo.getClass()).findProperties() ) {
+            if( isIdProperty(def) ) {
+                AnnotatedMember accessor = def.getAccessor();
+                accessor.fixAccess();
+                boolean mustGenerate = isObjectId(def) && accessor.getValue(pojo) == null;
+                return mustGenerate;
+            }
+        }
+        return false;
+    }
+
+    public Object getId(Object pojo) {
+        BasicBeanDescription beanDescription = beanDescription(pojo.getClass());
+        for( BeanPropertyDefinition def : beanDescription.findProperties() ) {
+            if( isIdProperty(def) ) {
+                AnnotatedMember accessor = def.getAccessor();
+                accessor.fixAccess();
+                Object id = accessor.getValue(pojo);
+                if( id instanceof String && isObjectId(def)) {
+                    return new ObjectId(id.toString());
+                } else {
+                    return id;
+                }
+            }
+        }
+        return null;
+    }
+
+    public void setObjectId(Object target, ObjectId id) {
+        for( BeanPropertyDefinition def : beanDescription(target.getClass()).findProperties() ) {
+            if( isIdProperty(def) ) {
+                AnnotatedMember accessor = def.getAccessor();
+                accessor.fixAccess();
+                if( accessor.getValue(target) != null ) {
+                    throw new IllegalArgumentException("Unable to set objectid on class: " + target.getClass());
+                }
+                AnnotatedMember field = def.getField();
+                field.fixAccess();
+                Class<?> type = field.getRawType();
+                if( ObjectId.class.isAssignableFrom(type) ) {
+                    field.setValue(target, id);
+                }
+                else if( type.equals(String.class) && isObjectId(def) ) {
+                    field.setValue(target, id.toString());
+                }
+                return;
+            }
+        }
+    }
+    
+    private static boolean isIdProperty(BeanPropertyDefinition property) {
+        return hasIdName(property) || hasIdAnnotation(property);
+    }
+    
+    private static boolean isObjectId(BeanPropertyDefinition property) {
+        boolean isObjectId = property.getPrimaryMember().getAnnotation(org.jongo.marshall.jackson.oid.ObjectId.class) != null 
+                || property.getPrimaryMember().getAnnotation(MongoObjectId.class) != null
+                || ObjectId.class.isAssignableFrom(property.getField().getRawType());
+        return isObjectId;
+    }
+    
+    private static boolean hasIdName( BeanPropertyDefinition property ) {
+        return "_id".equals(property.getName());
+    }
+    
+    private static boolean hasIdAnnotation( BeanPropertyDefinition property ) {
+        if( property == null ) return false;
+        AnnotatedMember accessor = property.getPrimaryMember();
+        if( accessor == null ) return false;
+        return 
+                accessor.getAnnotation(MongoId.class) != null ||
+                accessor.getAnnotation(Id.class) != null;
+    }
+    
+    private BasicBeanDescription beanDescription( Class<?> cls) {
+        BasicClassIntrospector bci = new BasicClassIntrospector();
+        return bci.forSerialization(mapper.getSerializationConfig(), mapper.constructType(cls), mapper.getSerializationConfig());
+    }
+}

--- a/src/main/java/org/jongo/marshall/jackson/JongoAnnotationIntrospector.java
+++ b/src/main/java/org/jongo/marshall/jackson/JongoAnnotationIntrospector.java
@@ -16,19 +16,52 @@
 
 package org.jongo.marshall.jackson;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
+
+import org.jongo.marshall.jackson.oid.Id;
 import org.jongo.marshall.jackson.oid.MongoId;
 import org.jongo.marshall.jackson.oid.MongoObjectId;
+import org.jongo.marshall.jackson.oid.ObjectId;
+import org.jongo.marshall.jackson.oid.ObjectIdDeserializer;
+import org.jongo.marshall.jackson.oid.ObjectIdSerializer;
 
-import java.lang.annotation.Annotation;
-
+@SuppressWarnings("deprecation")
 public class JongoAnnotationIntrospector extends NopAnnotationIntrospector {
+    private static final long serialVersionUID = 1L;
 
     @Override
-    public boolean isAnnotationBundle(Annotation ann) {
-        boolean isJongoId = ann.annotationType().equals(MongoId.class) || ann.annotationType().equals(MongoObjectId.class);
-        return isJongoId ? isJongoId : super.isAnnotationBundle(ann);
+    public Include findSerializationInclusion(Annotated a, Include defValue) {
+        return hasMongoObjectId( a ) ? Include.NON_NULL : defValue;
     }
 
+    @Override
+    public Object findSerializer(Annotated a) {
+        return hasMongoObjectId( a ) ? ObjectIdSerializer.class : super.findSerializer(a);
+    }
+    
+    @Override
+    public Object findDeserializer(Annotated a) {
+        return hasMongoObjectId( a ) ? ObjectIdDeserializer.class : super.findDeserializer(a);
+    }
 
+    @Override
+    public PropertyName findNameForSerialization(Annotated a) {
+        return hasMongoId( a ) ? new PropertyName("_id") : super.findNameForSerialization(a);
+    }
+    
+    @Override
+    public PropertyName findNameForDeserialization(Annotated a) {
+        return hasMongoId( a ) ? new PropertyName("_id") : super.findNameForDeserialization(a);
+    }
+    
+    private static boolean hasMongoId( Annotated a ) {
+        return a.hasAnnotation(MongoId.class) || a.hasAnnotation(Id.class);
+    }
+    
+    private static boolean hasMongoObjectId( Annotated a ) {
+        return a.hasAnnotation(MongoObjectId.class) || a.hasAnnotation(ObjectId.class);
+    }
 }

--- a/src/main/java/org/jongo/marshall/jackson/configuration/AnnotationModifier.java
+++ b/src/main/java/org/jongo/marshall/jackson/configuration/AnnotationModifier.java
@@ -19,18 +19,15 @@ package org.jongo.marshall.jackson.configuration;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import org.jongo.marshall.jackson.JongoAnnotationIntrospector;
 
 public class AnnotationModifier implements MapperModifier {
 
     public void modify(ObjectMapper mapper) {
         AnnotationIntrospector jongoIntrospector = new JongoAnnotationIntrospector();
-        AnnotationIntrospector defaultIntrospector = new JacksonAnnotationIntrospector();
+        AnnotationIntrospector defaultIntrospector = mapper.getSerializationConfig().getAnnotationIntrospector();
         AnnotationIntrospector pair = new AnnotationIntrospectorPair(jongoIntrospector, defaultIntrospector);
 
         mapper.setAnnotationIntrospector(pair);
-        mapper.getDeserializationConfig().with(pair);
-        mapper.getSerializationConfig().with(pair);
     }
 }

--- a/src/main/java/org/jongo/marshall/jackson/configuration/Mapping.java
+++ b/src/main/java/org/jongo/marshall/jackson/configuration/Mapping.java
@@ -64,4 +64,8 @@ public class Mapping {
         }
     }
 
+    public ObjectMapper getObjectMapper() {
+        return mapper;
+    }
+
 }

--- a/src/main/java/org/jongo/marshall/jackson/oid/MongoId.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/MongoId.java
@@ -16,13 +16,10 @@
 
 package org.jongo.marshall.jackson.oid;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.lang.annotation.Retention;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
-@JsonProperty("_id")
 public @interface MongoId {
 }

--- a/src/main/java/org/jongo/marshall/jackson/oid/MongoObjectId.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/MongoObjectId.java
@@ -16,18 +16,10 @@
 
 package org.jongo.marshall.jackson.oid;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
 import java.lang.annotation.Retention;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
-@JsonInclude(NON_NULL)
-@JsonSerialize(using = ObjectIdSerializer.class)
-@JsonDeserialize(using = ObjectIdDeserializer.class)
 public @interface MongoObjectId {
 }

--- a/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdDeserializer.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdDeserializer.java
@@ -18,23 +18,52 @@ package org.jongo.marshall.jackson.oid;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 
 import java.io.IOException;
 
+import org.bson.types.ObjectId;
+
 import static org.jongo.MongoCollection.MONGO_QUERY_OID;
 
-public class ObjectIdDeserializer extends JsonDeserializer<String> {
+public class ObjectIdDeserializer extends JsonDeserializer<Object> implements ContextualDeserializer {
 
+    private boolean fieldIsObjectId = false;
+    
+    public ObjectIdDeserializer() {
+        this(false);
+    }
+    
+    public ObjectIdDeserializer( boolean fieldIsObjectId ) {
+        this.fieldIsObjectId = fieldIsObjectId;
+    }
+    
     @Override
-    public String deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+    public Object deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
         TreeNode treeNode = jp.readValueAsTree();
         JsonNode oid = ((JsonNode) treeNode).get(MONGO_QUERY_OID);
-        if (oid != null)
-            return oid.asText();
-        else
-            return ((JsonNode) treeNode).asText();
+        if( fieldIsObjectId ) {
+            if( oid != null ) {
+                return new ObjectId(oid.asText());
+            } else {
+                return new ObjectId(((JsonNode)treeNode).asText());
+            }
+        }
+        else {
+            if (oid != null) {
+                return oid.asText();
+            } else {
+                return ((JsonNode) treeNode).asText();
+            }
+        }
+    }
+
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
+        return new ObjectIdDeserializer(ObjectId.class.isAssignableFrom(property.getType().getRawClass()));
     }
 }

--- a/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdSerializer.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdSerializer.java
@@ -17,16 +17,43 @@
 package org.jongo.marshall.jackson.oid;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+
 import org.bson.types.ObjectId;
 
 import java.io.IOException;
 
-public class ObjectIdSerializer extends JsonSerializer<String> {
+public class ObjectIdSerializer extends JsonSerializer<Object>
+  implements ContextualSerializer {
+    
+    boolean fieldIsObjectId = false;
+    
+    public ObjectIdSerializer() {
+        this(false);
+    }
+    
+    public ObjectIdSerializer( boolean serializeAsObjectId ) {
+        this.fieldIsObjectId = serializeAsObjectId;
+    }
 
     @Override
-    public void serialize(String value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-        jgen.writeObject(new ObjectId(value));
+    public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        if( value == null ) {
+            jgen.writeNull();
+        }
+        else if( fieldIsObjectId ) {
+            jgen.writeObject(value);
+        }
+        else {
+            jgen.writeObject(new ObjectId(value.toString()));
+        }
+    }
+
+    public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property) throws JsonMappingException {
+        return new ObjectIdSerializer(ObjectId.class.isAssignableFrom(property.getType().getRawClass()));
     }
 }

--- a/src/test/java/org/jongo/AggregateTest.java
+++ b/src/test/java/org/jongo/AggregateTest.java
@@ -16,11 +16,19 @@
 
 package org.jongo;
 
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.Lists;
 import com.mongodb.AggregationOptions;
 import com.mongodb.MongoCommandException;
+
+import org.jongo.marshall.jackson.JacksonMapper;
+import org.jongo.model.ExternalType;
+import org.jongo.model.ExternalType.ExternalTypeMixin;
+import org.jongo.model.Friend;
 import org.jongo.util.JongoTestCase;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -37,6 +45,16 @@ public class AggregateTest extends JongoTestCase {
 
 
     private MongoCollection collection;
+    private MongoCollection friendCollection;
+    private MongoCollection externalTypeCollection;
+    
+    @SuppressWarnings("serial")
+    public AggregateTest() {
+        super(new JacksonMapper.Builder()
+                .registerModule(new SimpleModule() {{
+                    this.setMixInAnnotation(ExternalType.class, ExternalTypeMixin .class);
+                }}).build());
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -47,10 +65,20 @@ public class AggregateTest extends JongoTestCase {
         collection.save(new Article("Zombie Panic", "Kirsty Mckay", "horror", "virus"));
         collection.save(new Article("Apocalypse Zombie", "Maberry Jonathan", "horror", "dead"));
         collection.save(new Article("World War Z", "Max Brooks", "horror", "virus", "pandemic"));
+        
+        friendCollection = createEmptyCollection("friends");
+        friendCollection.save(new Friend("William"));
+        friendCollection.save(new Friend("John"));
+        friendCollection.save(new Friend("Richard"));
+        
+        externalTypeCollection = createEmptyCollection("external_type");
+        externalTypeCollection.save(new ExternalType("value"));
     }
 
     @After
     public void tearDown() throws Exception {
+        dropCollection("external_type");
+        dropCollection("friends");
         dropCollection("articles");
     }
 
@@ -145,9 +173,36 @@ public class AggregateTest extends JongoTestCase {
             assertThat(MongoCommandException.class).isAssignableFrom(e.getClass());
         }
     }
+    
+    @Test
+    public void shouldPopulateIds() throws Exception {
+        List<Friend> friends = Lists.newArrayList(
+                (Iterable<Friend>)friendCollection.aggregate("{$project: {_id: '$_id', name: '$name'}}")
+          .as(Friend.class));
+        
+        assertThat(friends.isEmpty()).isEqualTo(false);
+        for( Friend friend : friends ) {
+            assertThat(friend.getId()).isNotNull();
+        }
+    }
+    
+    // this test is not working with the compatibility test suite.
+    @Ignore
+    @Test
+    public void shouldPopulateIdsWithMixins() throws Exception {
+        List<ExternalType> externalTypes = Lists.newArrayList(
+                (Iterable<ExternalType>)externalTypeCollection.aggregate("{$project: {_id: '$_id', name: '$name'}}")
+          .as(ExternalType.class));
+        
+        assertThat(externalTypes.size()).as("on found").isEqualTo(1);
+        for( ExternalType externalType : externalTypes ) {
+            assertThat(externalType.getId()).as("id not null").isNotNull();
+        }
+    }
 
     private final static class Article {
         private String title;
+        @SuppressWarnings("unused")
         private String author;
         private List<String> tags;
 

--- a/src/test/java/org/jongo/FindAndModifyTest.java
+++ b/src/test/java/org/jongo/FindAndModifyTest.java
@@ -18,6 +18,7 @@ package org.jongo;
 
 import com.mongodb.DBObject;
 import org.jongo.marshall.MarshallingException;
+import org.jongo.model.ExposableFriend;
 import org.jongo.model.Friend;
 import org.jongo.util.ErrorObject;
 import org.jongo.util.JongoTestCase;
@@ -27,6 +28,8 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
+
+import org.bson.types.ObjectId;
 
 public class FindAndModifyTest extends JongoTestCase {
 
@@ -166,6 +169,30 @@ public class FindAndModifyTest extends JongoTestCase {
                 return true;
             }
         });
+    }
+    
+    @Test
+    public void canUpsertByObjectId() throws Exception {
+        Friend expected = new Friend(new ObjectId(), "John");
+        Friend actual = collection.findAndModify("{_id: #}", expected.getId())
+                .upsert()
+                .returnNew()
+                .with("{$setOnInsert: {name: #}}", "John")
+                .as(Friend.class);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void canUpsertByStringId() throws Exception {
+        ExposableFriend expected = new ExposableFriend(new ObjectId().toString(), "John");
+        ExposableFriend actual = collection.findAndModify("{_id: #}", expected.getId())
+                .upsert()
+                .returnNew()
+                .with("{$setOnInsert: {name: #}}", "John")
+                .as(ExposableFriend.class);
+
+        assertThat(actual).isEqualTo(expected);        
     }
 
 }

--- a/src/test/java/org/jongo/NewAnnotationsCompatibilitySuiteTest.java
+++ b/src/test/java/org/jongo/NewAnnotationsCompatibilitySuiteTest.java
@@ -36,8 +36,6 @@ public class NewAnnotationsCompatibilitySuiteTest {
             AnnotationIntrospector pair = new AnnotationIntrospectorPair(primary, secondary);
 
             mapper.setAnnotationIntrospector(pair);
-            mapper.getDeserializationConfig().with(pair);
-            mapper.getSerializationConfig().with(pair);
         }
     }
 

--- a/src/test/java/org/jongo/marshall/jackson/IdSpecTest.java
+++ b/src/test/java/org/jongo/marshall/jackson/IdSpecTest.java
@@ -1,0 +1,137 @@
+package org.jongo.marshall.jackson;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.mongodb.WriteResult;
+
+import org.bson.types.ObjectId;
+import org.jongo.MongoCollection;
+import org.jongo.MongoCursor;
+import org.jongo.util.JongoEmbeddedRule;
+import org.jongo.util.MongoEmbeddedRule;
+
+import static org.jongo.model.IdSpecSet.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests how Jongo handles different field/annotation/mixin combinations.
+ * 
+ * @author Christian Trimble
+ *
+ */
+@RunWith(Parameterized.class)
+public class IdSpecTest {
+    @Parameters
+    public static List<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {
+            {StringIdBare.class, noMixIn(), StringIdBare.class},
+            {BrokenStringIdField.class, StringIdMongoIdMixIn.class, StringIdBare.class},
+            {BrokenStringIdField.class, StringIdMongoIdMongoObjectIdMixIn.class, ObjectIdBare.class},
+            {StringIdBare.class, String_IdMongoObjectIdMixIn.class, ObjectIdBare.class},
+            {StringIdJsonProperty.class, noMixIn(), StringIdBare.class},
+            {BrokenStringIdJsonProperty.class, StringIdMongoIdMixIn.class, StringIdBare.class},
+            {StringIdMongoId.class, noMixIn(), StringIdBare.class},
+            {StringIdMongoObjectId.class, noMixIn(), ObjectIdBare.class},
+            {StringIdMongoIdMongoObjectId.class, noMixIn(), ObjectIdBare.class},
+            {ObjectIdBare.class, noMixIn(), ObjectIdBare.class},
+            {ObjectIdJsonProperty.class, noMixIn(), ObjectIdBare.class},
+            {ObjectIdMongoId.class, noMixIn(), ObjectIdBare.class},
+            {ObjectIdMongoObjectId.class, noMixIn(), ObjectIdBare.class},
+            {ObjectIdMongoIdMongoObjectId.class, noMixIn(), ObjectIdBare.class}
+        });
+    }
+  
+  public static @ClassRule MongoEmbeddedRule mongoRule = new MongoEmbeddedRule();
+  public @Rule JongoEmbeddedRule jongoRule = new JongoEmbeddedRule(mongoRule);
+
+  private Class<?> spec;
+  private Class<?> equiv;
+  private Class<?> mixIn;
+  private MongoCollection collection;
+  
+  public IdSpecTest( Class<?> spec, Class<?> mixIn, Class<?> equiv ) {
+      this.spec = spec;
+      this.equiv = equiv;
+      this.mixIn = mixIn;
+      if( this.mixIn != null ) {
+          jongoRule.withMixIn(spec, this.mixIn);
+      }
+  }
+  
+  @Before
+  public void setUp() throws UnknownHostException {
+      this.collection = jongoRule.createEmptyCollection("spec"); 
+  }
+  
+  @Test
+  public void saveAndFind() {
+      collection.drop();
+      Object instance = newInstanceWithId(spec, new ObjectId());
+      WriteResult saveResult = collection.save(instance);
+      assertThat(saveResult.getN(), equalTo(1));
+      
+      MongoCursor<?> found = collection.find("{_id: #}", mongoId(instance)).as(spec);
+ 
+      assertThat(found.count(), equalTo(1));
+      assertThat(id(found.next()), equalTo(id(instance)));
+  }
+  
+  @Test
+  public void marshalledHasIdField() {
+      Object instance = newInstanceWithId(spec, new ObjectId());
+      org.jongo.bson.BsonDocument document = jongoRule.getMapper().getMarshaller().marshall(instance);
+      assertThat(document.toDBObject().containsField("_id"), equalTo(true));
+  }
+  
+  @Test 
+  public void marshalledHasCorrectIdType() {
+      Object instance = newInstanceWithId(spec, new ObjectId());
+      org.jongo.bson.BsonDocument document = jongoRule.getMapper().getMarshaller().marshall(instance);
+      Object id = mongoId(instance);
+      assertThat(document.toDBObject().get("_id"), instanceOf(id.getClass()));  
+  }
+  
+  @Test
+  public void marchalRoundTrip() {
+      Object instance = newInstanceWithId(spec, new ObjectId());
+      org.jongo.bson.BsonDocument document = jongoRule.getMapper().getMarshaller().marshall(instance);
+      Object roundTrip = jongoRule.getMapper().getUnmarshaller().unmarshall(document, spec);
+      assertThat(id(roundTrip), equalTo(id(instance)));  
+  }
+  
+  public Object mongoId(Object instance) {
+      Object id = id(instance);
+      if( String.class.isAssignableFrom(id.getClass()) ) {
+          if( equiv == StringIdBare.class ) {
+              return id;
+          }
+          else if( equiv == ObjectIdBare.class ) {
+              return new ObjectId((String)id);
+          }
+      }
+      else if( ObjectId.class.isAssignableFrom(id.getClass()) ) {
+          if( equiv == StringIdBare.class ) {
+              return id.toString();
+          }
+          else if( equiv == ObjectIdBare.class ) {
+              return id;
+          }
+      }
+      throw new IllegalStateException("cannot build mongo id");
+  }
+  
+  private static Class<?> noMixIn() {
+      return null;
+  }
+}

--- a/src/test/java/org/jongo/marshall/jackson/JacksonMapperTest.java
+++ b/src/test/java/org/jongo/marshall/jackson/JacksonMapperTest.java
@@ -24,12 +24,16 @@ import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
 import com.fasterxml.jackson.databind.module.SimpleDeserializers;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.mongodb.BasicDBObject;
 import org.bson.types.ObjectId;
 import org.jongo.Mapper;
 import org.jongo.ObjectIdUpdater;
 import org.jongo.bson.Bson;
 import org.jongo.bson.BsonDocument;
+import org.jongo.model.ExposableFriend;
+import org.jongo.model.ExternalFriend;
+import org.jongo.model.ExternalType;
 import org.jongo.model.Friend;
 import org.jongo.query.Query;
 import org.jongo.query.QueryFactory;
@@ -80,7 +84,40 @@ public class JacksonMapperTest {
 
         assertThat(document.toString()).isEqualTo("{ \"firstName\" : \"Robert\"}");
     }
+    
+    @SuppressWarnings("serial")
+    @Test
+    public void canUseMixins() throws Exception {
+        String id = "563667f82249254c42530fe3";
+        ExternalType external = new ExternalType(id, "Robert");
 
+        Mapper mapper = new JacksonMapper.Builder()
+                .registerModule(new SimpleModule() {{
+                    this.setMixInAnnotation(ExternalType.class, ExternalType.ExternalTypeMixin.class);
+                }})
+                .build();
+
+        BsonDocument document = mapper.getMarshaller().marshall(external);
+
+        assertThat(document.toString()).isEqualTo("{ \"_id\" : { \"$oid\" : \""+id+"\"} , \"name\" : \"Robert\"}");
+    }
+    
+    @SuppressWarnings("serial")
+    @Test
+    public void canUseAnnotations() throws Exception {
+        String id = "563667f82249254c42530fe3";
+        ExposableFriend external = new ExposableFriend(id, "Robert");
+
+        Mapper mapper = new JacksonMapper.Builder()
+                .registerModule(new SimpleModule() {{
+                    this.setMixInAnnotation(ExternalType.class, ExternalType.ExternalTypeMixin.class);
+                }})
+                .build();
+
+        BsonDocument document = mapper.getMarshaller().marshall(external);
+
+        assertThat(document.toString()).isEqualTo("{ \"name\" : \"Robert\" , \"_id\" : { \"$oid\" : \""+id+"\"}}");
+    }
 
     @Test
     public void canAddModule() throws Exception {

--- a/src/test/java/org/jongo/model/ExposableFriend.java
+++ b/src/test/java/org/jongo/model/ExposableFriend.java
@@ -21,6 +21,8 @@ import org.jongo.marshall.jackson.oid.MongoId;
 import org.jongo.marshall.jackson.oid.MongoObjectId;
 import org.jongo.marshall.jackson.oid.ObjectId;
 
+import com.google.common.base.Objects;
+
 public class ExposableFriend {
 
     @Id
@@ -53,6 +55,21 @@ public class ExposableFriend {
 
     public void setName(String name) {
         this.name = name;
+    }
+    
+    public boolean equals( Object o ) {
+        if( o == null || !(o instanceof ExposableFriend)) return false;
+        ExposableFriend ef = (ExposableFriend)o;
+        
+        return Objects.equal(id, ef.id) &&
+                Objects.equal(name, ef.name);
+    }
+    
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("id", id)
+                .add("name", name)
+                .toString();
     }
 
 }

--- a/src/test/java/org/jongo/model/ExternalType.java
+++ b/src/test/java/org/jongo/model/ExternalType.java
@@ -1,0 +1,78 @@
+package org.jongo.model;
+
+import org.jongo.marshall.jackson.oid.Id;
+import org.jongo.marshall.jackson.oid.MongoId;
+import org.jongo.marshall.jackson.oid.MongoObjectId;
+import org.jongo.marshall.jackson.oid.ObjectId;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Models a type coming from a third party tool like JsonSchema2Pojo.
+ * 
+ * @author Christian Trimble
+ */
+@SuppressWarnings("deprecation")
+public class ExternalType {
+    /**
+     * Mixin that supplies all of the mongo specific annotations.
+     * 
+     * @author Christian Trimble
+     */
+    public static abstract class ExternalTypeMixin {
+        @MongoObjectId
+        @MongoId
+        @ObjectId
+        @Id
+        public String id;
+
+        @MongoObjectId
+        @MongoId
+        @ObjectId
+        @Id
+        public abstract String getId();
+
+        @MongoObjectId
+        @MongoId
+        @ObjectId
+        @Id
+        public abstract void setId( String id );
+    }
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("name")
+    private String name;
+
+    public ExternalType() {}
+
+    public ExternalType( String name ) {
+        this.name = name;
+    }
+
+    public ExternalType( String id, String name ) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/org/jongo/model/IdSpecSet.java
+++ b/src/test/java/org/jongo/model/IdSpecSet.java
@@ -1,0 +1,143 @@
+package org.jongo.model;
+
+import java.lang.reflect.Field;
+
+import org.bson.types.ObjectId;
+import org.jongo.marshall.jackson.oid.MongoId;
+import org.jongo.marshall.jackson.oid.MongoObjectId;
+
+import com.fasterxml.jackson.annotation.*;
+
+/**
+ * A set of example id specifications.
+ * 
+ * @author Christian Trimble
+ */
+public class IdSpecSet {
+    public static class BrokenStringIdField {
+        public String id;
+    }
+
+    public static class StringIdBare {
+        public String _id;
+    }
+
+    public static class StringIdJsonProperty {
+        @JsonProperty("_id")
+        public String id;
+    }
+
+    public static class BrokenStringIdJsonProperty {
+        @JsonProperty("id")
+        public String id;
+    }
+
+    public static class StringIdMongoId {
+        @MongoId
+        public String id;
+    }
+
+    public static class StringIdMongoObjectId {
+        @MongoObjectId
+        public String _id;
+    }
+
+    public static class StringIdMongoIdMongoObjectId {
+        @MongoId
+        @MongoObjectId
+        public String id;
+    }
+
+    public static class ObjectIdBare {
+        public ObjectId _id;
+    }
+
+    public static class ObjectIdJsonProperty {
+        @JsonProperty("_id")
+        public ObjectId id;
+    }
+
+    public static class ObjectIdMongoId {
+        @MongoId
+        public ObjectId id;
+    }
+
+    public static class ObjectIdMongoObjectId {
+        @MongoObjectId
+        public ObjectId _id;
+    }
+
+    public static class ObjectIdMongoIdMongoObjectId {
+        @MongoId
+        @MongoObjectId
+        public ObjectId id;
+    }
+
+    public static abstract class StringIdMongoIdMixIn {
+        @MongoId
+        public String id;
+    }
+
+    public static abstract class String_IdMongoObjectIdMixIn {
+        @MongoObjectId
+        public String _id;
+    }
+
+    public static abstract class StringIdMongoObjectIdMixIn {
+        @MongoObjectId
+        public String id;
+    }
+
+    public static abstract class StringIdMongoIdMongoObjectIdMixIn {
+        @MongoId
+        @MongoObjectId
+        public String id;
+    }
+
+    public static <T> T id( T specInstance, Object id ) {
+        Field field = idField(specInstance.getClass());
+        try {
+            field.setAccessible(true);
+            if( ObjectId.class.isAssignableFrom(field.getType()) ) {
+                field.set(specInstance,  (ObjectId)id);
+            }
+            else {
+                field.set(specInstance, id.toString());
+            }
+            return specInstance;
+        } catch( Exception e ) {
+            throw new RuntimeException("could not set id field", e);
+        }
+    }
+
+    public static Object id(Object specInstance) {
+        Field field = idField(specInstance.getClass());
+
+        field.setAccessible(true);
+        try {
+            return field.get(specInstance);
+        } catch (Exception e) {
+            throw new RuntimeException("could not set id", e);
+        }
+    }
+
+    public static <T> T newInstanceWithId(Class<T> spec, ObjectId id) {
+        try {
+            return id(spec.newInstance(), id);
+        } catch (Exception e) {
+            throw new RuntimeException("could not create spec instance", e);
+        }
+    }
+
+    public static Field idField( Class<?> spec ) {
+        try {
+            return spec.getDeclaredField("_id");
+        } catch (NoSuchFieldException e) {
+            try {
+                return spec.getDeclaredField("id");
+            } catch (NoSuchFieldException e1) {
+                throw new RuntimeException("_id field missing", e1);
+            }
+        }
+    }
+}

--- a/src/test/java/org/jongo/util/JongoEmbeddedRule.java
+++ b/src/test/java/org/jongo/util/JongoEmbeddedRule.java
@@ -1,0 +1,104 @@
+package org.jongo.util;
+
+import static org.junit.Assume.assumeTrue;
+
+import java.net.UnknownHostException;
+import java.util.Set;
+
+import org.jongo.Jongo;
+import org.jongo.Mapper;
+import org.jongo.MongoCollection;
+import org.jongo.marshall.jackson.JacksonMapper;
+import org.jongo.marshall.jackson.configuration.MapperModifier;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import com.mongodb.CommandResult;
+import com.mongodb.DB;
+
+/**
+ * A JUnit test rule for testing Jongo with embedded Mongo.
+ * 
+ * @author Benoit Guérout
+ * @author yamsellem
+ * @author Alexandre Dutra
+ * @author Christian Trimble
+ */
+public class JongoEmbeddedRule implements TestRule {
+
+    private Jongo jongo;
+    private Mapper mapper;
+    private MongoEmbeddedRule mongoRule;
+    private Set<String> collectionNames = Sets.newHashSet();
+    private JacksonMapper.Builder mapperBuilder = new JacksonMapper.Builder();
+    
+    public JongoEmbeddedRule( MongoEmbeddedRule mongoRule ) {
+        this.mongoRule = mongoRule;
+    }
+
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                MongoResource mongoResource = mongoRule.getResource();
+                mapper = mapperBuilder.build();
+                jongo = new Jongo(mongoResource.getDb("test_jongo"), mapper);
+                try {
+                  base.evaluate();
+                } finally {
+                    for( String collectionName : collectionNames ) {
+                        dropCollection(collectionName);
+                    }
+                }
+            }
+        };
+    }
+    
+    public MongoCollection createEmptyCollection(String collectionName) throws UnknownHostException {
+        collectionNames.add(collectionName);
+        MongoCollection col = jongo.getCollection(collectionName);
+        col.drop();
+        return col;
+    }
+
+    public void dropCollection(String collectionName) throws UnknownHostException {
+        getDatabase().getCollection(collectionName).drop();
+    }
+
+    public DB getDatabase() throws UnknownHostException {
+        return jongo.getDatabase();
+    }
+
+    public Jongo getJongo() {
+        return jongo;
+    }
+
+    public Mapper getMapper() {
+        return mapper;
+    }
+
+    public void assumeThatMongoVersionIsGreaterThan(String expectedVersion) throws UnknownHostException {
+        int expectedVersionAsInt = Integer.valueOf(expectedVersion.replaceAll("\\.", ""));
+        CommandResult buildInfo = getDatabase().command("buildInfo");
+        String version = (String) buildInfo.get("version");
+        int currentVersion = Integer.valueOf(version.replaceAll("\\.", ""));
+        assumeTrue(currentVersion >= expectedVersionAsInt);
+    }
+
+    public void prepareMarshallingStrategy(Mapper mapper) {
+        this.mapper = mapper;
+        this.jongo = new Jongo(mongoRule.getResource().getDb("test_jongo"), mapper);
+    }
+
+    public JongoEmbeddedRule withMixIn(final Class<?> spec, final Class<?> mixIn) {
+        mapperBuilder.addModifier(new MapperModifier() {
+            public void modify(ObjectMapper mapper) {
+                mapper.addMixInAnnotations(spec, mixIn);
+            }});
+        return this;
+    }
+
+}

--- a/src/test/java/org/jongo/util/JongoTestCase.java
+++ b/src/test/java/org/jongo/util/JongoTestCase.java
@@ -36,7 +36,11 @@ public abstract class JongoTestCase {
     private Mapper mapper;
 
     public JongoTestCase() {
-        this.mapper = new JacksonMapper.Builder().build();
+        this(new JacksonMapper.Builder().build());
+    }
+    
+    protected JongoTestCase( Mapper mapper ) {
+        this.mapper = mapper;
         this.jongo = new Jongo(mongoResource.getDb("test_jongo"), mapper);
     }
 

--- a/src/test/java/org/jongo/util/MongoEmbeddedRule.java
+++ b/src/test/java/org/jongo/util/MongoEmbeddedRule.java
@@ -1,0 +1,29 @@
+package org.jongo.util;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * A JUnit rule for testing with embedded Mongo.
+ * 
+ * @author Alexandre Dutra
+ * @author Christian Trimble
+ */
+public class MongoEmbeddedRule implements TestRule {
+    private MongoResource mongoResource;
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                mongoResource = new MongoResource();
+                base.evaluate();
+            }
+        };
+    }
+    
+    public MongoResource getResource() {
+        return mongoResource;
+    }
+
+}


### PR DESCRIPTION
In Jongo 1.2, `@MongoId` and `@MongoObjectId` only work under a few specific conditions.  This PR aims to make `@MongoId` and `@MongoObjectId` more general, using a parameterized test (`org.jongo.marshall.jackson.IdSpecTest`).

### Goal

Get all of the following to be generally true:

- If Jackson sees a property named `_id`, that is the id property for Mongo.
- If Jackson sees `@MongoId`on a property, that property is named `_id` according to Jackson.
- If Jackson sees `@MongoObjectId` on a property, that property is serialized as an `ObjectId`.
- `@MongoId` and `@MongoObjectId` will not alter other `ObjectMapper` instances that see them.

### What has changed

- Reflection is no longer used to inspect instances for the `_id` property and its value.  Instead, Jackson's view of the type is used to determine the property's value and type in Mongo.  The implementation can be found in `org.jongo.marshall.jackson.JacksonObjectIdUpdater`.
- The Serializer and Deserializer were widened, so that property/annotation combinations like `public @MongoObjectId ObjectId _id;` will just no op.
- The *@*MongoId and *@*MongoObjectId annotations are no longer AnnotationBundles, as these were not getting applied for MixIns.  This functionality is now supported directly by `org.jongo.marshall.jackson.JongoAnnotationIntrospector`.
- JUnit rules `org.jongo.util.JongoEmbeddedRule` and `org.jongo.util.MongoEmbeddedRule` have been introduced with the same functionality as `JongoTestCase`.
- Several other tests were added to the test suite dealing with IDs and MixIns.

Fixes #272