### PR TITLE
add cursor addOption

### DIFF
--- a/src/main/java/org/jongo/MongoCursor.java
+++ b/src/main/java/org/jongo/MongoCursor.java
@@ -61,4 +61,9 @@ public class MongoCursor<E> implements Iterator<E>, Iterable<E>, Closeable {
     public int count() {
         return cursor.count();
     }
+    
+    public MongoCursor<E> addOption(final int option) {
+        cursor.addOption(option);
+        return this;
+    }
 }


### PR DESCRIPTION
When I use Mongo Driver, I need call cursor.addOption(Bytes.QUERYOPTION_NOTIMEOUT).
So I add this wrapper method to MongoCursor.

Then can use it after 'as' method.
ex: collection.find(query).as(Model.class).addOption(Bytes.QUERYOPTION_NOTIMEOUT)
