### PR TITLE
Fixing NullPointerException when annotation is on Getter

### DIFF
--- a/src/main/java/org/jongo/marshall/jackson/JacksonObjectIdUpdater.java
+++ b/src/main/java/org/jongo/marshall/jackson/JacksonObjectIdUpdater.java
@@ -84,7 +84,7 @@ public class JacksonObjectIdUpdater implements ObjectIdUpdater {
     private static boolean isObjectId(BeanPropertyDefinition property) {
         boolean isObjectId = property.getPrimaryMember().getAnnotation(org.jongo.marshall.jackson.oid.ObjectId.class) != null 
                 || property.getPrimaryMember().getAnnotation(MongoObjectId.class) != null
-                || ObjectId.class.isAssignableFrom(property.getField().getRawType());
+                || ObjectId.class.isAssignableFrom(property.getAccessor().getRawType());
         return isObjectId;
     }
     

--- a/src/test/java/org/jongo/JacksonAnnotationsHandlingTest.java
+++ b/src/test/java/org/jongo/JacksonAnnotationsHandlingTest.java
@@ -17,6 +17,7 @@
 package org.jongo;
 
 import org.bson.types.ObjectId;
+import org.jongo.marshall.jackson.oid.MongoId;
 import org.jongo.util.JongoTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -85,6 +86,17 @@ public class JacksonAnnotationsHandlingTest extends JongoTestCase {
         assertThat(result._id).isEqualTo(id);
     }
 
+    @Test
+    public void canHandleAnnotatedGetter() throws Exception {
+        POJOWithAnnotatedGetter pojo = new POJOWithAnnotatedGetter();
+        pojo.setId("id");
+
+        collection.save(pojo);
+
+        POJOWithAnnotatedGetter result = collection.findOne().as(POJOWithAnnotatedGetter.class);
+        assertThat(result.getId()).isEqualTo(pojo.getId());
+    }
+
     public static class POJOWithMisspelledGetter {
 
         private ObjectId _id;
@@ -109,4 +121,18 @@ public class JacksonAnnotationsHandlingTest extends JongoTestCase {
         private long _id;
 
     }
+
+    public static class POJOWithAnnotatedGetter {
+        private String someId;
+
+        @MongoId
+        public String getId() {
+            return someId;
+        }
+
+        public void setId(String id) {
+            someId = id;
+        }
+    }
+
 }


### PR DESCRIPTION
We have a use-case where a getter is annotated.
and we get NPE.
This is a fix as fields are not mandatory, but getters are.

```
java.lang.NullPointerException
	at org.jongo.marshall.jackson.JacksonObjectIdUpdater.isObjectId(JacksonObjectIdUpdater.java:87)
	at org.jongo.marshall.jackson.JacksonObjectIdUpdater.mustGenerateObjectId(JacksonObjectIdUpdater.java:34)
	at org.jongo.Insert.preparePojo(Insert.java:72)
	at org.jongo.Insert.save(Insert.java:47)
	at org.jongo.MongoCollection.save(MongoCollection.java:132)
	at org.jongo.JacksonAnnotationsHandlingTest.canHandleAnnotatedGetter(JacksonAnnotationsHandlingTest.java:94)
```