### PR TITLE
Partial migration to new MongoDB driver API

### DIFF
--- a/src/main/java/org/jongo/FindOne.java
+++ b/src/main/java/org/jongo/FindOne.java
@@ -16,9 +16,11 @@
 
 package org.jongo;
 
-import com.mongodb.DBCollection;
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.ReadPreference;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
 import org.jongo.marshall.Unmarshaller;
 import org.jongo.query.Query;
 import org.jongo.query.QueryFactory;
@@ -28,13 +30,13 @@ import static org.jongo.ResultHandlerFactory.newResultHandler;
 public class FindOne {
 
     private final Unmarshaller unmarshaller;
-    private final DBCollection collection;
+    private final MongoCollection<BasicDBObject> collection;
     private final ReadPreference readPreference;
     private final Query query;
     private Query fields, orderBy;
     private final QueryFactory queryFactory;
 
-    FindOne(DBCollection collection, ReadPreference readPreference, Unmarshaller unmarshaller, QueryFactory queryFactory, String query, Object... parameters) {
+    FindOne(MongoCollection<BasicDBObject> collection, ReadPreference readPreference, Unmarshaller unmarshaller, QueryFactory queryFactory, String query, Object... parameters) {
         this.unmarshaller = unmarshaller;
         this.collection = collection;
         this.readPreference = readPreference;
@@ -47,8 +49,9 @@ public class FindOne {
     }
 
     public <T> T map(ResultHandler<T> resultHandler) {
-        DBObject result = collection.findOne(query.toDBObject(), getFieldsAsDBObject(), getOrderByAsDBObject(), readPreference);
-        return result == null ? null : resultHandler.map(result);
+        FindIterable<DBObject> result = collection.find(query.toBson(), DBObject.class);
+        DBObject first = result.first();
+        return first == null ? null : resultHandler.map(first);
     }
 
     public FindOne projection(String fields) {

--- a/src/main/java/org/jongo/Jongo.java
+++ b/src/main/java/org/jongo/Jongo.java
@@ -16,35 +16,32 @@
 
 package org.jongo;
 
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import org.jongo.bson.BsonDBDecoder;
-import org.jongo.bson.BsonDBEncoder;
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
 import org.jongo.marshall.jackson.JacksonMapper;
 import org.jongo.query.Query;
 
 public class Jongo {
 
-    private final DB database;
+    private final MongoDatabase database;
     private final Mapper mapper;
 
-    public Jongo(DB database) {
+    public Jongo(MongoDatabase database) {
         this(database, new JacksonMapper.Builder().build());
     }
 
-    public Jongo(DB database, Mapper mapper) {
+    public Jongo(MongoDatabase database, Mapper mapper) {
         this.database = database;
         this.mapper = mapper;
     }
 
-    public MongoCollection getCollection(String name) {
-        DBCollection dbCollection = database.getCollection(name);
-        dbCollection.setDBDecoderFactory(BsonDBDecoder.FACTORY);
-        dbCollection.setDBEncoderFactory(BsonDBEncoder.FACTORY);
-        return new MongoCollection(dbCollection, mapper);
+    public JongoCollection getCollection(String name) {
+        MongoCollection<BasicDBObject> collection = database.getCollection(name, BasicDBObject.class);
+        return new JongoCollection(collection, mapper);
     }
 
-    public DB getDatabase() {
+    public MongoDatabase getDatabase() {
         return database;
     }
 

--- a/src/main/java/org/jongo/MongoCursor.java
+++ b/src/main/java/org/jongo/MongoCursor.java
@@ -16,33 +16,35 @@
 
 package org.jongo;
 
-import com.mongodb.DBCursor;
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
+import com.mongodb.client.MongoIterable;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+//TODO I believe this class is now obsolete: the MongoDriver implements Iterable already
 public class MongoCursor<E> implements Iterator<E>, Iterable<E>, Closeable {
 
-    private final DBCursor cursor;
+    private final MongoIterable<BasicDBObject> cursor;
     private final ResultHandler<E> resultHandler;
 
-    public MongoCursor(DBCursor cursor, ResultHandler<E> resultHandler) {
+    public MongoCursor(MongoIterable<BasicDBObject> cursor, ResultHandler<E> resultHandler) {
         this.cursor = cursor;
         this.resultHandler = resultHandler;
     }
 
     public boolean hasNext() {
-        return cursor.hasNext();
+        return cursor.iterator().hasNext();
     }
 
     public E next() {
         if (!hasNext())
             throw new NoSuchElementException();
 
-        DBObject dbObject = cursor.next();
+        DBObject dbObject = cursor.iterator().next();
         return resultHandler.map(dbObject);
     }
 
@@ -51,14 +53,15 @@ public class MongoCursor<E> implements Iterator<E>, Iterable<E>, Closeable {
     }
 
     public Iterator<E> iterator() {
-        return new MongoCursor<E>(cursor.copy(), resultHandler);
+        return new MongoCursor<E>(cursor, resultHandler);
     }
 
     public void close() throws IOException {
-        cursor.close();
+        //TODO does it need to close?
     }
 
+    //TODO does it make sense anymore?
     public int count() {
-        return cursor.count();
+        return 0;
     }
 }

--- a/src/main/java/org/jongo/Oid.java
+++ b/src/main/java/org/jongo/Oid.java
@@ -16,7 +16,7 @@
 
 package org.jongo;
 
-import static org.jongo.MongoCollection.MONGO_QUERY_OID;
+import static org.jongo.JongoCollection.MONGO_QUERY_OID;
 
 public class Oid {
 

--- a/src/main/java/org/jongo/QueryModifier.java
+++ b/src/main/java/org/jongo/QueryModifier.java
@@ -16,8 +16,12 @@
 
 package org.jongo;
 
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBCursor;
+import com.mongodb.client.FindIterable;
 
 public interface QueryModifier {
     void modify(DBCursor cursor);
+
+    void modify(FindIterable<BasicDBObject> iterable);
 }

--- a/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdDeserializer.java
+++ b/src/main/java/org/jongo/marshall/jackson/oid/ObjectIdDeserializer.java
@@ -18,18 +18,13 @@ package org.jongo.marshall.jackson.oid;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.BeanProperty;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import org.bson.types.ObjectId;
 
 import java.io.IOException;
 
-import org.bson.types.ObjectId;
-
-import static org.jongo.MongoCollection.MONGO_QUERY_OID;
+import static org.jongo.JongoCollection.MONGO_QUERY_OID;
 
 public class ObjectIdDeserializer extends JsonDeserializer<Object> implements ContextualDeserializer {
 

--- a/src/main/java/org/jongo/query/BsonQueryFactory.java
+++ b/src/main/java/org/jongo/query/BsonQueryFactory.java
@@ -17,6 +17,7 @@
 package org.jongo.query;
 
 import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.util.JSON;
 import com.mongodb.util.JSONCallback;
@@ -27,13 +28,10 @@ import org.jongo.bson.BsonDocument;
 import org.jongo.marshall.Marshaller;
 import org.jongo.marshall.MarshallingException;
 
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static java.nio.ByteOrder.*;
 
 public class BsonQueryFactory implements QueryFactory {
 
@@ -52,6 +50,10 @@ public class BsonQueryFactory implements QueryFactory {
 
         public DBObject toDBObject() {
             return dbo;
+        }
+
+        public org.bson.conversions.Bson toBson() {
+            return new BasicDBObject(dbo.toMap());
         }
     }
 

--- a/src/main/java/org/jongo/query/Query.java
+++ b/src/main/java/org/jongo/query/Query.java
@@ -17,8 +17,11 @@
 package org.jongo.query;
 
 import com.mongodb.DBObject;
+import org.bson.conversions.Bson;
 
 public interface Query {
 
     DBObject toDBObject();
+
+    Bson toBson();
 }

--- a/src/test/java/org/jongo/AggregateTest.java
+++ b/src/test/java/org/jongo/AggregateTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.Lists;
 import com.mongodb.AggregationOptions;
 import com.mongodb.MongoCommandException;
-
 import org.jongo.marshall.jackson.JacksonMapper;
 import org.jongo.model.ExternalType;
 import org.jongo.model.ExternalType.ExternalTypeMixin;
@@ -44,9 +43,9 @@ import static org.mockito.Mockito.*;
 public class AggregateTest extends JongoTestCase {
 
 
-    private MongoCollection collection;
-    private MongoCollection friendCollection;
-    private MongoCollection externalTypeCollection;
+    private JongoCollection collection;
+    private JongoCollection friendCollection;
+    private JongoCollection externalTypeCollection;
     
     @SuppressWarnings("serial")
     public AggregateTest() {

--- a/src/test/java/org/jongo/AnnotationsMisusedTest.java
+++ b/src/test/java/org/jongo/AnnotationsMisusedTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnnotationsMisusedTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/BinaryTest.java
+++ b/src/test/java/org/jongo/BinaryTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertNull;
 public class BinaryTest extends JongoTestCase {
 
     private Binary friendId;
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/CommandTest.java
+++ b/src/test/java/org/jongo/CommandTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CommandTest extends JongoTestCase {
 
     private Jongo jongo;
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {
@@ -80,7 +80,7 @@ public class CommandTest extends JongoTestCase {
     @Test
     public void canRunAGeoNearCommand() throws Exception {
 
-        MongoCollection safeCollection = collection.withWriteConcern(WriteConcern.SAFE);
+        JongoCollection safeCollection = collection.withWriteConcern(WriteConcern.SAFE);
         safeCollection.insert("{loc:{lat:48.690833,lng:9.140556}, name:'Paris'}");
         safeCollection.ensureIndex("{loc:'2d'}");
 

--- a/src/test/java/org/jongo/CountTest.java
+++ b/src/test/java/org/jongo/CountTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CountTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/DistinctTest.java
+++ b/src/test/java/org/jongo/DistinctTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class DistinctTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
     private String wallStreetAvenue;
 
     @Before

--- a/src/test/java/org/jongo/FindAndModifyTest.java
+++ b/src/test/java/org/jongo/FindAndModifyTest.java
@@ -17,6 +17,7 @@
 package org.jongo;
 
 import com.mongodb.DBObject;
+import org.bson.types.ObjectId;
 import org.jongo.marshall.MarshallingException;
 import org.jongo.model.ExposableFriend;
 import org.jongo.model.Friend;
@@ -29,11 +30,9 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
-import org.bson.types.ObjectId;
-
 public class FindAndModifyTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/FindOneTest.java
+++ b/src/test/java/org/jongo/FindOneTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FindOneTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/FindPartialFieldTest.java
+++ b/src/test/java/org/jongo/FindPartialFieldTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FindPartialFieldTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
     private Friend friend;
 
     @Before

--- a/src/test/java/org/jongo/FindSkipSortLimitTest.java
+++ b/src/test/java/org/jongo/FindSkipSortLimitTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FindSkipSortLimitTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/FindTest.java
+++ b/src/test/java/org/jongo/FindTest.java
@@ -36,7 +36,7 @@ import static org.jongo.Oid.withOid;
 
 public class FindTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/FindWithModifierTest.java
+++ b/src/test/java/org/jongo/FindWithModifierTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FindWithModifierTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/FindWithResultMapperTest.java
+++ b/src/test/java/org/jongo/FindWithResultMapperTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FindWithResultMapperTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/InsertTest.java
+++ b/src/test/java/org/jongo/InsertTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class InsertTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/JacksonAnnotationsHandlingTest.java
+++ b/src/test/java/org/jongo/JacksonAnnotationsHandlingTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class JacksonAnnotationsHandlingTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/JongoCollectionTest.java
+++ b/src/test/java/org/jongo/JongoCollectionTest.java
@@ -28,9 +28,9 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MongoCollectionTest extends JongoTestCase {
+public class JongoCollectionTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/JongoTest.java
+++ b/src/test/java/org/jongo/JongoTest.java
@@ -30,7 +30,7 @@ public class JongoTest extends JongoTestCase {
 
         Jongo jongo = new Jongo(getDatabase());
 
-        MongoCollection collection = jongo.getCollection("collection-name");
+        JongoCollection collection = jongo.getCollection("collection-name");
 
         assertThat(collection).isNotNull();
         assertThat(collection.getName()).isEqualTo("collection-name");

--- a/src/test/java/org/jongo/NestedPolymorphismTest.java
+++ b/src/test/java/org/jongo/NestedPolymorphismTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class NestedPolymorphismTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/NonPojoTest.java
+++ b/src/test/java/org/jongo/NonPojoTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class NonPojoTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/PolymorphismTest.java
+++ b/src/test/java/org/jongo/PolymorphismTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class PolymorphismTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/RemoveTest.java
+++ b/src/test/java/org/jongo/RemoveTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RemoveTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/SaveTest.java
+++ b/src/test/java/org/jongo/SaveTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SaveTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
     
     @SuppressWarnings("serial")
     public SaveTest() {
@@ -190,7 +190,7 @@ public class SaveTest extends JongoTestCase {
     public void canUpdateAPojoWithACustomId() throws Exception {
 
         ExternalFriend externalFriend = new ExternalFriend("122", "John");
-        MongoCollection safeCollection = collection.withWriteConcern(WriteConcern.SAFE);
+        JongoCollection safeCollection = collection.withWriteConcern(WriteConcern.SAFE);
 
         safeCollection.save(externalFriend);
         externalFriend.setName("Robert");

--- a/src/test/java/org/jongo/UpdateTest.java
+++ b/src/test/java/org/jongo/UpdateTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class UpdateTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/WriteConcernTest.java
+++ b/src/test/java/org/jongo/WriteConcernTest.java
@@ -30,11 +30,11 @@ import static org.mockito.Mockito.*;
 public class WriteConcernTest {
 
     DBCollection mockedDBCollection = mock(DBCollection.class);
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {
-        collection = new MongoCollection(mockedDBCollection, new JacksonMapper.Builder().build());
+        collection = new JongoCollection(mockedDBCollection, new JacksonMapper.Builder().build());
     }
 
     @Test

--- a/src/test/java/org/jongo/bench/BenchUtil.java
+++ b/src/test/java/org/jongo/bench/BenchUtil.java
@@ -16,16 +16,10 @@
 
 package org.jongo.bench;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
-import com.mongodb.Mongo;
-import com.mongodb.MongoClient;
-import com.mongodb.WriteConcern;
+import com.mongodb.*;
 import org.jongo.Jongo;
+import org.jongo.JongoCollection;
 import org.jongo.Mapper;
-import org.jongo.MongoCollection;
 import org.jongo.marshall.jackson.JacksonMapper;
 import org.jongo.model.Coordinate;
 import org.jongo.model.Friend;
@@ -58,7 +52,7 @@ class BenchUtil {
         return nativeMongo.getDB("jongo").getCollection("benchmark");
     }
 
-    public static MongoCollection getCollectionFromJongo(Mapper mapper) throws UnknownHostException {
+    public static JongoCollection getCollectionFromJongo(Mapper mapper) throws UnknownHostException {
         Mongo mongo = new MongoClient();
         DB db = mongo.getDB("jongo");
         Jongo jongo = new Jongo(db, mapper);
@@ -66,7 +60,7 @@ class BenchUtil {
     }
 
     public static void injectFriendsIntoDB(int nbDocuments) throws UnknownHostException {
-        MongoCollection collection = getCollectionFromJongo(new JacksonMapper.Builder().build());
+        JongoCollection collection = getCollectionFromJongo(new JacksonMapper.Builder().build());
         collection.drop();
         for (int i = 0; i < nbDocuments; i++) {
             collection.withWriteConcern(WriteConcern.SAFE).save(createFriend(i));

--- a/src/test/java/org/jongo/bench/FindBench.java
+++ b/src/test/java/org/jongo/bench/FindBench.java
@@ -22,7 +22,7 @@ import com.google.caliper.SimpleBenchmark;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
-import org.jongo.MongoCollection;
+import org.jongo.JongoCollection;
 import org.jongo.marshall.jackson.JacksonMapper;
 import org.jongo.model.Coordinate;
 import org.jongo.model.Friend;
@@ -35,7 +35,7 @@ public class FindBench extends SimpleBenchmark {
     private static final int NB_DOCUMENTS = 100000;
     @Param({"1"})
     int size = 1;
-    private MongoCollection bsonCollection;
+    private JongoCollection bsonCollection;
     private DBCollection dbCollection;
 
     protected void setUp() throws Exception {

--- a/src/test/java/org/jongo/bench/SaveBench.java
+++ b/src/test/java/org/jongo/bench/SaveBench.java
@@ -21,7 +21,7 @@ import com.google.caliper.Runner;
 import com.google.caliper.SimpleBenchmark;
 import com.mongodb.DBCollection;
 import com.mongodb.WriteConcern;
-import org.jongo.MongoCollection;
+import org.jongo.JongoCollection;
 import org.jongo.marshall.jackson.JacksonMapper;
 
 import static org.jongo.bench.BenchUtil.*;
@@ -32,7 +32,7 @@ public class SaveBench extends SimpleBenchmark {
     int size = 1;
 
     private DBCollection dbCollection;
-    private MongoCollection bsonCollection;
+    private JongoCollection bsonCollection;
 
     protected void setUp() throws Exception {
 

--- a/src/test/java/org/jongo/marshall/DocumentMarshallingTest.java
+++ b/src/test/java/org/jongo/marshall/DocumentMarshallingTest.java
@@ -19,7 +19,7 @@ package org.jongo.marshall;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import org.bson.types.*;
-import org.jongo.MongoCollection;
+import org.jongo.JongoCollection;
 import org.jongo.model.Friend;
 import org.jongo.util.JongoTestCase;
 import org.junit.After;
@@ -35,7 +35,7 @@ import static org.assertj.core.data.MapEntry.entry;
 
 public class DocumentMarshallingTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/marshall/ParameterQueryBindingTest.java
+++ b/src/test/java/org/jongo/marshall/ParameterQueryBindingTest.java
@@ -19,7 +19,7 @@ package org.jongo.marshall;
 import com.google.common.collect.Lists;
 import com.mongodb.DBObject;
 import org.bson.types.ObjectId;
-import org.jongo.MongoCollection;
+import org.jongo.JongoCollection;
 import org.jongo.MongoCursor;
 import org.jongo.RawResultHandler;
 import org.jongo.model.Coordinate;
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ParameterQueryBindingTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/marshall/jackson/IdSpecTest.java
+++ b/src/test/java/org/jongo/marshall/jackson/IdSpecTest.java
@@ -1,9 +1,11 @@
 package org.jongo.marshall.jackson;
 
-import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.List;
-
+import com.mongodb.WriteResult;
+import org.bson.types.ObjectId;
+import org.jongo.JongoCollection;
+import org.jongo.MongoCursor;
+import org.jongo.util.JongoEmbeddedRule;
+import org.jongo.util.MongoEmbeddedRule;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -12,17 +14,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import com.mongodb.WriteResult;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
 
-import org.bson.types.ObjectId;
-import org.jongo.MongoCollection;
-import org.jongo.MongoCursor;
-import org.jongo.util.JongoEmbeddedRule;
-import org.jongo.util.MongoEmbeddedRule;
-
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.jongo.model.IdSpecSet.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 /**
  * Tests how Jongo handles different field/annotation/mixin combinations.
@@ -58,7 +57,7 @@ public class IdSpecTest {
   private Class<?> spec;
   private Class<?> equiv;
   private Class<?> mixIn;
-  private MongoCollection collection;
+    private JongoCollection collection;
   
   public IdSpecTest( Class<?> spec, Class<?> mixIn, Class<?> equiv ) {
       this.spec = spec;

--- a/src/test/java/org/jongo/marshall/jackson/ParameterBindingWithJacksonTest.java
+++ b/src/test/java/org/jongo/marshall/jackson/ParameterBindingWithJacksonTest.java
@@ -2,7 +2,7 @@ package org.jongo.marshall.jackson;
 
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.jongo.MongoCollection;
+import org.jongo.JongoCollection;
 import org.jongo.util.JongoTestCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ParameterBindingWithJacksonTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/spike/MongoDumpTest.java
+++ b/src/test/java/org/jongo/spike/MongoDumpTest.java
@@ -23,7 +23,7 @@ import com.mongodb.WriteConcern;
 import de.undercouch.bson4jackson.BsonFactory;
 import org.bson.BSONObject;
 import org.bson.BasicBSONObject;
-import org.jongo.MongoCollection;
+import org.jongo.JongoCollection;
 import org.jongo.util.JongoTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MongoDumpTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/jongo/spike/QuestionsSpikeTest.java
+++ b/src/test/java/org/jongo/spike/QuestionsSpikeTest.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.DBObject;
 import com.mongodb.QueryBuilder;
 import org.jongo.Jongo;
+import org.jongo.JongoCollection;
 import org.jongo.Mapper;
-import org.jongo.MongoCollection;
 import org.jongo.ResultHandler;
 import org.jongo.bson.Bson;
 import org.jongo.bson.BsonDocument;
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class QuestionsSpikeTest extends JongoTestCase {
 
-    private MongoCollection collection;
+    private JongoCollection collection;
 
     @Before
     public void setUp() throws Exception {
@@ -161,7 +161,7 @@ public class QuestionsSpikeTest extends JongoTestCase {
             }
         }).build();
         Jongo jongo = new Jongo(getDatabase(), mapper);
-        MongoCollection friends = jongo.getCollection("friends");
+        JongoCollection friends = jongo.getCollection("friends");
         Friend friend = new Friend("Peter", "31 rue des Lilas");
         friends.save(friend);
 

--- a/src/test/java/org/jongo/util/JongoEmbeddedRule.java
+++ b/src/test/java/org/jongo/util/JongoEmbeddedRule.java
@@ -1,23 +1,22 @@
 package org.jongo.util;
 
-import static org.junit.Assume.assumeTrue;
-
-import java.net.UnknownHostException;
-import java.util.Set;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import com.mongodb.CommandResult;
+import com.mongodb.client.MongoDatabase;
 import org.jongo.Jongo;
+import org.jongo.JongoCollection;
 import org.jongo.Mapper;
-import org.jongo.MongoCollection;
 import org.jongo.marshall.jackson.JacksonMapper;
 import org.jongo.marshall.jackson.configuration.MapperModifier;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Sets;
-import com.mongodb.CommandResult;
-import com.mongodb.DB;
+import java.net.UnknownHostException;
+import java.util.Set;
+
+import static org.junit.Assume.assumeTrue;
 
 /**
  * A JUnit test rule for testing Jongo with embedded Mongo.
@@ -56,10 +55,10 @@ public class JongoEmbeddedRule implements TestRule {
             }
         };
     }
-    
-    public MongoCollection createEmptyCollection(String collectionName) throws UnknownHostException {
+
+    public JongoCollection createEmptyCollection(String collectionName) throws UnknownHostException {
         collectionNames.add(collectionName);
-        MongoCollection col = jongo.getCollection(collectionName);
+        JongoCollection col = jongo.getCollection(collectionName);
         col.drop();
         return col;
     }
@@ -68,7 +67,7 @@ public class JongoEmbeddedRule implements TestRule {
         getDatabase().getCollection(collectionName).drop();
     }
 
-    public DB getDatabase() throws UnknownHostException {
+    public MongoDatabase getDatabase() throws UnknownHostException {
         return jongo.getDatabase();
     }
 

--- a/src/test/java/org/jongo/util/JongoTestCase.java
+++ b/src/test/java/org/jongo/util/JongoTestCase.java
@@ -17,10 +17,10 @@
 package org.jongo.util;
 
 import com.mongodb.CommandResult;
-import com.mongodb.DB;
+import com.mongodb.client.MongoDatabase;
 import org.jongo.Jongo;
+import org.jongo.JongoCollection;
 import org.jongo.Mapper;
-import org.jongo.MongoCollection;
 import org.jongo.marshall.jackson.JacksonMapper;
 import org.junit.BeforeClass;
 
@@ -49,8 +49,8 @@ public abstract class JongoTestCase {
         mongoResource = new MongoResource();
     }
 
-    protected MongoCollection createEmptyCollection(String collectionName) throws UnknownHostException {
-        MongoCollection col = jongo.getCollection(collectionName);
+    protected JongoCollection createEmptyCollection(String collectionName) throws UnknownHostException {
+        JongoCollection col = jongo.getCollection(collectionName);
         col.drop();
         return col;
     }
@@ -59,7 +59,7 @@ public abstract class JongoTestCase {
         getDatabase().getCollection(collectionName).drop();
     }
 
-    protected DB getDatabase() throws UnknownHostException {
+    protected MongoDatabase getDatabase() throws UnknownHostException {
         return jongo.getDatabase();
     }
 


### PR DESCRIPTION
Initial work on the API migration. I haven't finished it yet due to a few road blocks:

The new driver doesn't use the BSON decoder/encoder that was previously used by Jongo. I didn't understand why that was needed, but I removed the code since it no longer has the methods. It now introduces a new API called Codec that seems to automatically do what Jongo previously did with the ObjectId unmarshalling. Again, I'm not sure that I got it right, any help would be very appreciated.

Another roadblock I got into was with the ``Insert`` class, where it has an Instance of ``LazyIdDbObject`` which I was not able to convert to the new ``Bson`` interface in order to use with the new collection methods.

I will keep working on this until @bguerout can confirm a release.

Lets hope for the best.