### PR TITLE
Resolve issues with TokenBuffer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
         <mongo.min.version>3.0.0</mongo.min.version>
         <mongo.max.version>3.2.2</mongo.max.version>
         <mongo.version>[${mongo.min.version},${mongo.max.version}]</mongo.version>
-        <jackson.version>2.6.2</jackson.version>
-        <bson4jackson.version>2.6.0</bson4jackson.version>
+        <jackson.version>2.6.3</jackson.version>
+        <bson4jackson.version>2.7.0</bson4jackson.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/jongo/marshall/jackson/bson4jackson/BsonDeserializers.java
+++ b/src/main/java/org/jongo/marshall/jackson/bson4jackson/BsonDeserializers.java
@@ -16,6 +16,8 @@
 
 package org.jongo.marshall.jackson.bson4jackson;
 
+import com.fasterxml.jackson.core.Base64Variants;
+import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
@@ -23,8 +25,10 @@ import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleDeserializers;
+import com.fasterxml.jackson.databind.node.BinaryNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.POJONode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.mongodb.DBObject;
 import com.mongodb.util.JSON;
@@ -33,6 +37,7 @@ import org.bson.types.BSONTimestamp;
 import org.bson.types.Binary;
 import org.bson.types.MaxKey;
 import org.bson.types.MinKey;
+import org.bson.types.ObjectId;
 
 import java.io.IOException;
 import java.util.Date;
@@ -44,7 +49,8 @@ class BsonDeserializers extends SimpleDeserializers {
         addDeserializer(MinKey.class, new MinKeyDeserializer());
         addDeserializer(MaxKey.class, new MaxKeyDeserializer());
         addDeserializer(Binary.class, new BinaryDeserializer());
-        addDeserializer(DBObject.class, new NativeDeserializer());
+        addDeserializer(DBObject.class, new NativeDeserializer<DBObject>());
+        addDeserializer(ObjectId.class, new ObjectIdDeserializer());
         addDeserializer(BSONTimestamp.class, new BSONTimestampDeserializer());
     }
 
@@ -67,14 +73,40 @@ class BsonDeserializers extends SimpleDeserializers {
     private static class MinKeyDeserializer extends JsonDeserializer<MinKey> {
         @Override
         public MinKey deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+          TreeNode tree = jp.getCodec().readTree(jp);
+          if( tree.isObject() ) {
+            int value = ((ValueNode)tree.get("$minKey")).asInt();
+            if( value == 1 ) {
+              return new MinKey();
+            }
+            throw ctxt.mappingException(MinKey.class);
+          } else if( tree instanceof POJONode ) {
+            return (MinKey)((POJONode)tree).getPojo();
+          } else if(tree instanceof TextNode ) {
             return new MinKey();
+          } else {
+            throw ctxt.mappingException(MinKey.class);
+          }
         }
     }
 
     private static class MaxKeyDeserializer extends JsonDeserializer<MaxKey> {
         @Override
         public MaxKey deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+          TreeNode tree = jp.getCodec().readTree(jp);
+          if( tree.isObject() ) {
+            int value = ((ValueNode)tree.get("$maxKey")).asInt();
+            if( value == 1 ) {
+              return new MaxKey();
+            }
+            throw ctxt.mappingException(MaxKey.class);
+          } else if( tree instanceof POJONode ) {
+            return (MaxKey)((POJONode)tree).getPojo();
+          } else if(tree instanceof TextNode ) {
             return new MaxKey();
+          } else {
+            throw ctxt.mappingException(MaxKey.class);
+          }
         }
     }
 
@@ -89,9 +121,37 @@ class BsonDeserializers extends SimpleDeserializers {
     private static class BinaryDeserializer extends JsonDeserializer<Binary> {
         @Override
         public Binary deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-            Object object = jp.getEmbeddedObject();
-            return new Binary((byte[]) object);
+          TreeNode tree = jp.getCodec().readTree(jp);
+          if( tree.isObject() ) {
+            byte[] binary = Base64Variants.MIME_NO_LINEFEEDS.decode(((ValueNode)tree.get("$binary")).asText());
+            byte type = Integer.valueOf(((ValueNode)tree.get("$type")).asText().toLowerCase(), 16).byteValue();
+            return new Binary(type, binary);
+          } else if( tree instanceof POJONode ) {
+            return (Binary)((POJONode)tree).getPojo();
+          } else if( tree instanceof BinaryNode ) {
+            return new Binary(((BinaryNode)tree).binaryValue());
+          } else {
+            throw ctxt.mappingException(ObjectId.class);
+          }
         }
+    }
+    
+    private static class ObjectIdDeserializer extends JsonDeserializer<ObjectId> {
+      
+      @Override
+      public ObjectId deserialize(JsonParser jp, DeserializationContext ctxt)
+          throws IOException, JsonProcessingException {
+        TreeNode tree = jp.getCodec().readTree(jp);
+        if( tree.isObject() ) {
+          String hexString = ((ValueNode)tree.get("$oid")).asText();
+          return new ObjectId(hexString);
+        } else if( tree instanceof POJONode ) {
+          return (ObjectId)((POJONode)tree).getPojo();
+        } else {
+          throw ctxt.mappingException(ObjectId.class);
+        }
+      }
+      
     }
 
     private static class BSONTimestampDeserializer extends JsonDeserializer<BSONTimestamp> {
@@ -99,14 +159,15 @@ class BsonDeserializers extends SimpleDeserializers {
         public BSONTimestamp deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
           TreeNode tree = jp.getCodec().readTree(jp);
           if( tree.isObject() ) {
-            ObjectNode object = (ObjectNode)tree;
-            int time = ((ValueNode)tree.get("time")).asInt();
-            int inc = ((ValueNode)tree.get("inc")).asInt();
+            TreeNode timestamp = tree.get("$timestamp");
+            int time = ((ValueNode)timestamp.get("t")).asInt();
+            int inc = ((ValueNode)timestamp.get("i")).asInt();
             return new BSONTimestamp(time, inc);
           } else if( tree instanceof POJONode ) {
             return (BSONTimestamp)((POJONode)tree).getPojo();
           } else {
-            return null;
+            throw ctxt.mappingException(BSONTimestamp.class);
           }
         }
-    }}
+    }
+}

--- a/src/main/java/org/jongo/marshall/jackson/bson4jackson/BsonSerializers.java
+++ b/src/main/java/org/jongo/marshall/jackson/bson4jackson/BsonSerializers.java
@@ -39,14 +39,26 @@ class BsonSerializers extends SimpleSerializers {
     static class MaxKeySerializer extends JsonSerializer<MaxKey> {
 
         public void serialize(MaxKey obj, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
-            ((MongoBsonGenerator) jsonGenerator).writeMaxKey(obj);
+            if( jsonGenerator instanceof MongoBsonGenerator ) {
+              ((MongoBsonGenerator) jsonGenerator).writeMaxKey(obj);
+            } else {
+              jsonGenerator.writeStartObject();
+              jsonGenerator.writeNumberField("$maxKey", 1);
+              jsonGenerator.writeEndObject();
+            }
         }
     }
 
     static class MinKeySerializer extends JsonSerializer<MinKey> {
 
         public void serialize(MinKey obj, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
-            ((MongoBsonGenerator) jsonGenerator).writeMinKey(obj);
+            if( jsonGenerator instanceof MongoBsonGenerator ) {
+              ((MongoBsonGenerator) jsonGenerator).writeMinKey(obj);
+            } else {
+              jsonGenerator.writeStartObject();
+              jsonGenerator.writeNumberField("$minKey", 1);
+              jsonGenerator.writeEndObject();
+            }
         }
     }
 
@@ -57,8 +69,11 @@ class BsonSerializers extends SimpleSerializers {
             ((MongoBsonGenerator) jsonGenerator).writeBSONTimestamp(obj);
           } else {
             jsonGenerator.writeStartObject();
-            jsonGenerator.writeNumberField("time", obj.getTime());
-            jsonGenerator.writeNumberField("inc", obj.getInc());
+            jsonGenerator.writeFieldName("$timestamp");
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeNumberField("t", obj.getTime());
+            jsonGenerator.writeNumberField("i", obj.getInc());
+            jsonGenerator.writeEndObject();
             jsonGenerator.writeEndObject();
           }
         }
@@ -71,7 +86,9 @@ class BsonSerializers extends SimpleSerializers {
             ((MongoBsonGenerator) jsonGenerator).writeNativeObjectId(obj);
           }
           else {
-            jsonGenerator.writeString(obj.toHexString());
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField("$oid", obj.toHexString());
+            jsonGenerator.writeEndObject();
           }
         }
     }
@@ -79,7 +96,15 @@ class BsonSerializers extends SimpleSerializers {
     static class BinarySerializer extends JsonSerializer<Binary> {
 
         public void serialize(Binary obj, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
-            ((MongoBsonGenerator) jsonGenerator).writeBinary(obj);
+            if( jsonGenerator instanceof MongoBsonGenerator ) {
+              ((MongoBsonGenerator) jsonGenerator).writeBinary(obj);
+            }
+            else {
+              jsonGenerator.writeStartObject();
+              jsonGenerator.writeBinaryField("$binary", obj.getData());
+              jsonGenerator.writeStringField("$type", Integer.toHexString(obj.getType()).toUpperCase());
+              jsonGenerator.writeEndObject();
+            }
         }
     }
 

--- a/src/main/java/org/jongo/marshall/jackson/bson4jackson/BsonSerializers.java
+++ b/src/main/java/org/jongo/marshall/jackson/bson4jackson/BsonSerializers.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleSerializers;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+
 import org.bson.types.*;
 
 import java.io.IOException;
@@ -51,14 +53,26 @@ class BsonSerializers extends SimpleSerializers {
     static class BSONTimestampSerializer extends JsonSerializer<BSONTimestamp> {
 
         public void serialize(BSONTimestamp obj, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+          if( jsonGenerator instanceof MongoBsonGenerator ) {
             ((MongoBsonGenerator) jsonGenerator).writeBSONTimestamp(obj);
+          } else {
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeNumberField("time", obj.getTime());
+            jsonGenerator.writeNumberField("inc", obj.getInc());
+            jsonGenerator.writeEndObject();
+          }
         }
     }
 
     static class BsonObjectIdSerializer extends JsonSerializer<ObjectId> {
 
         public void serialize(ObjectId obj, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+          if( jsonGenerator instanceof MongoBsonGenerator ) {
             ((MongoBsonGenerator) jsonGenerator).writeNativeObjectId(obj);
+          }
+          else {
+            jsonGenerator.writeString(obj.toHexString());
+          }
         }
     }
 

--- a/src/test/java/org/jongo/FindOneTest.java
+++ b/src/test/java/org/jongo/FindOneTest.java
@@ -16,9 +16,14 @@
 
 package org.jongo;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mongodb.ReadPreference;
+
+import org.bson.types.BSONTimestamp;
 import org.bson.types.ObjectId;
 import org.jongo.marshall.MarshallingException;
+import org.jongo.marshall.jackson.oid.MongoId;
 import org.jongo.model.Friend;
 import org.jongo.util.ErrorObject;
 import org.jongo.util.IdResultHandler;
@@ -29,6 +34,8 @@ import org.junit.Test;
 
 import static junit.framework.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
 
 public class FindOneTest extends JongoTestCase {
 
@@ -155,4 +162,134 @@ public class FindOneTest extends JongoTestCase {
 
         assertThat(friend.getAddress()).isEqualTo("21 Wall Street Av.");
     }
+    
+    @Test
+    public void canSaveAndMapAPojoWithoutId() throws Exception {
+
+        collection.save(new NoId("test"));
+
+        NoId noId = collection.findOne().as(NoId.class);
+
+        assertThat(noId.value).isEqualTo("test");
+    }
+
+    private static class NoId {
+        final String value;
+
+        @JsonCreator
+        public NoId(@JsonProperty("value") String value) {
+            this.value = value;
+        }
+    }
+    
+    @Test
+    public void canSaveAndMapAPojoStringCreatorAndObjectId() throws Exception {
+
+      ObjectId id = new ObjectId();
+        collection.save(new StringCreatorAndObjectId("test").withObjectId(id));
+
+        StringCreatorAndObjectId noId = collection.findOne().as(StringCreatorAndObjectId.class);
+
+        assertThat(noId.value).isEqualTo("test");
+        assertThat(noId.getId()).isEqualTo(id);
+    }
+
+    private static class StringCreatorAndObjectId {
+        protected ObjectId id;
+        final String value;
+
+        @JsonCreator
+        public StringCreatorAndObjectId(@JsonProperty("value") String value) {
+            this.value = value;
+        }
+        
+        @MongoId
+        public ObjectId getId() {
+          return id;
+        }
+        
+        public void setId( ObjectId id ) {
+          this.id = id;
+        }
+        
+        public StringCreatorAndObjectId withObjectId( ObjectId id ) {
+          this.id = id;
+          return this;
+        }
+    }
+
+    @Test
+    public void canSaveAndMapAPojoWithObjectIdCreator() throws Exception {
+
+      ObjectId value = new ObjectId();
+      
+        collection.save(new ObjectIdCreator(value));
+
+        ObjectIdCreator noId = collection.findOne().as(ObjectIdCreator.class);
+
+        assertThat(noId.value).isEqualTo(value);
+    }
+
+    private static class ObjectIdCreator {
+        final ObjectId value;
+
+        @JsonCreator
+        public ObjectIdCreator(@JsonProperty("value") ObjectId value) {
+            this.value = value;
+        }
+    }
+
+
+    @Test
+    public void canSaveAndMapAPojoWithDateCreator() throws Exception {
+
+      Date value = new Date();
+      
+        collection.save(new DateCreator(value));
+
+        DateCreator noId = collection.findOne().as(DateCreator.class);
+
+        assertThat(noId.value).isEqualTo(value);
+    }
+
+    private static class DateCreator {
+        final Date value;
+
+        @JsonCreator
+        public DateCreator(@JsonProperty("value") Date value) {
+            this.value = value;
+        }
+    }
+    
+    @Test
+    public void canSaveWithDateFieldAndMapWithout() {
+      DateField dateField = new DateField(new ObjectId());
+      dateField.date = new BSONTimestamp();
+      
+      collection.save(dateField);
+
+      IdOnly mapped = collection.findOne().as(IdOnly.class);
+
+      assertThat(mapped._id).isEqualTo(dateField._id);
+    }
+    
+    private static class IdOnly {
+      public final ObjectId _id;
+      
+      @JsonCreator
+      public IdOnly(@MongoId @JsonProperty ObjectId _id) {
+        this._id = _id;
+      }
+    }
+    
+    private static class DateField extends IdOnly {
+      @JsonProperty
+      public BSONTimestamp date;
+      
+      @JsonCreator
+      public DateField(@JsonProperty ObjectId _id) {
+        super(_id);
+      }      
+    }
+
 }


### PR DESCRIPTION
This PR is not yet complete.  Related to #257.

When Jackson needs a field's value before it instantiates a type containing that field, it will use a TokenBuffer to deserialize the field.  This occurs with the 'JsonCreator' annotation, since fields must be injected into the constructor.  It can also happen with 'id' fields and polymorphism, since fields before the 'discriminator' field must be deserialized before an instance can be created.