### PR TITLE
API improvements for use with lambdas.

### DIFF
--- a/src/main/java/org/jongo/Aggregate.java
+++ b/src/main/java/org/jongo/Aggregate.java
@@ -19,6 +19,8 @@ package org.jongo;
 import com.mongodb.AggregationOptions;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
+
+import org.jongo.function.Consumer;
 import org.jongo.marshall.Unmarshaller;
 import org.jongo.query.QueryFactory;
 
@@ -50,6 +52,11 @@ public class Aggregate {
         DBObject dbQuery = queryFactory.createQuery(pipelineOperator, parameters).toDBObject();
         pipeline.add(dbQuery);
         return this;
+    }
+    
+    public Aggregate with(Consumer<Aggregate> operations) {
+      operations.accept(this);
+      return this;
     }
 
     public <T> ResultsIterator<T> as(final Class<T> clazz) {

--- a/src/main/java/org/jongo/Find.java
+++ b/src/main/java/org/jongo/Find.java
@@ -20,6 +20,8 @@ import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.ReadPreference;
+
+import org.jongo.function.Consumer;
 import org.jongo.marshall.Unmarshaller;
 import org.jongo.query.Query;
 import org.jongo.query.QueryFactory;
@@ -111,6 +113,11 @@ public class Find {
     public Find with(QueryModifier queryModifier) {
         this.modifiers.add(queryModifier);
         return this;
+    }
+    
+    public Find with(Consumer<Find> operations) {
+      operations.accept(this);
+      return this;
     }
 
     private DBObject getFieldsAsDBObject() {

--- a/src/main/java/org/jongo/FindAndModify.java
+++ b/src/main/java/org/jongo/FindAndModify.java
@@ -24,6 +24,8 @@ import org.jongo.query.QueryFactory;
 
 import static org.jongo.ResultHandlerFactory.newResultHandler;
 
+import org.jongo.function.Consumer;
+
 public class FindAndModify {
 
     private final DBCollection collection;
@@ -93,7 +95,12 @@ public class FindAndModify {
         this.upsert = true;
         return this;
     }
-
+  
+    public FindAndModify with(Consumer<FindAndModify> operations) {
+      operations.accept(this);
+      return this;
+    }
+    
     private DBObject getAsDBObject(Query query) {
         return query == null ? null : query.toDBObject();
     }

--- a/src/main/java/org/jongo/FindOne.java
+++ b/src/main/java/org/jongo/FindOne.java
@@ -25,6 +25,8 @@ import org.jongo.query.QueryFactory;
 
 import static org.jongo.ResultHandlerFactory.newResultHandler;
 
+import org.jongo.function.Consumer;
+
 public class FindOne {
 
     private final Unmarshaller unmarshaller;
@@ -64,6 +66,11 @@ public class FindOne {
     public FindOne orderBy(String orderBy) {
         this.orderBy = queryFactory.createQuery(orderBy);
         return this;
+    }
+  
+    public FindOne with(Consumer<FindOne> operations) {
+      operations.accept(this);
+      return this;
     }
 
     private DBObject getFieldsAsDBObject() {

--- a/src/main/java/org/jongo/Update.java
+++ b/src/main/java/org/jongo/Update.java
@@ -18,6 +18,7 @@ package org.jongo;
 
 import com.mongodb.*;
 import org.bson.LazyBSONObject;
+import org.jongo.function.Consumer;
 import org.jongo.query.Query;
 import org.jongo.query.QueryFactory;
 
@@ -76,6 +77,11 @@ public class Update {
     public Update multi() {
         this.multi = true;
         return this;
+    }
+    
+    public Update with(Consumer<Update> operations) {
+      operations.accept(this);
+      return this;
     }
 
     private Query createQuery(String query, Object[] parameters) {

--- a/src/main/java/org/jongo/function/Consumer.java
+++ b/src/main/java/org/jongo/function/Consumer.java
@@ -1,0 +1,5 @@
+package org.jongo.function;
+
+public interface Consumer<T> {
+  public void accept(T t);
+}

--- a/src/test/java/org/jongo/AggregateTest.java
+++ b/src/test/java/org/jongo/AggregateTest.java
@@ -19,6 +19,8 @@ package org.jongo;
 import com.google.common.collect.Lists;
 import com.mongodb.AggregationOptions;
 import com.mongodb.MongoCommandException;
+
+import org.jongo.function.Consumer;
 import org.jongo.model.ExternalType;
 import org.jongo.model.Friend;
 import org.jongo.model.TypeWithNested;
@@ -157,6 +159,21 @@ public class AggregateTest extends JongoTestCase {
     public void canAggregateWithManyOperators() throws Exception {
 
         Iterator<Article> articles = collection.aggregate("{$match:{tags:'virus'}}").and("{$limit:1}").as(Article.class);
+
+        articles.next();
+        assertThat(articles.hasNext()).isFalse();
+    }
+
+    @Test
+    public void canAggregateWithFunctionalOperators() throws Exception {
+      
+        Consumer<Aggregate> limit = new Consumer<Aggregate>() {
+            public void accept(Aggregate t) {
+                t.and("{$limit:1}");
+            }
+        };
+
+        Iterator<Article> articles = collection.aggregate("{$match:{tags:'virus'}}").with(limit).as(Article.class);
 
         articles.next();
         assertThat(articles.hasNext()).isFalse();

--- a/src/test/java/org/jongo/FindAndModifyTest.java
+++ b/src/test/java/org/jongo/FindAndModifyTest.java
@@ -18,6 +18,7 @@ package org.jongo;
 
 import com.mongodb.DBObject;
 import org.bson.types.ObjectId;
+import org.jongo.function.Consumer;
 import org.jongo.marshall.MarshallingException;
 import org.jongo.model.ExposableFriend;
 import org.jongo.model.Friend;
@@ -188,6 +189,23 @@ public class FindAndModifyTest extends JongoTestCase {
         ExposableFriend actual = collection.findAndModify("{_id: #}", expected.getId())
                 .upsert()
                 .returnNew()
+                .with("{$setOnInsert: {name: #}}", "John")
+                .as(ExposableFriend.class);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void canUpsertWithOperators() throws Exception {
+        Consumer<FindAndModify> returnNew = new Consumer<FindAndModify>(){
+          public void accept(FindAndModify t) {
+            t.returnNew();
+          }
+        };
+        ExposableFriend expected = new ExposableFriend(new ObjectId().toString(), "John");
+        ExposableFriend actual = collection.findAndModify("{_id: #}", expected.getId())
+                .upsert()
+                .with(returnNew)
                 .with("{$setOnInsert: {name: #}}", "John")
                 .as(ExposableFriend.class);
 

--- a/src/test/java/org/jongo/FindOneTest.java
+++ b/src/test/java/org/jongo/FindOneTest.java
@@ -16,8 +16,10 @@
 
 package org.jongo;
 
+import com.mongodb.DBObject;
 import com.mongodb.ReadPreference;
 import org.bson.types.ObjectId;
+import org.jongo.function.Consumer;
 import org.jongo.marshall.MarshallingException;
 import org.jongo.model.Friend;
 import org.jongo.util.ErrorObject;
@@ -152,6 +154,24 @@ public class FindOneTest extends JongoTestCase {
         collection.save(new Friend("John", "22 Wall Street Av."));
 
         Friend friend = collection.findOne().orderBy("{address:1}").as(Friend.class);
+
+        assertThat(friend.getAddress()).isEqualTo("21 Wall Street Av.");
+    }
+
+    @Test
+    public void canFindWithOperations() throws Exception {
+      
+        Consumer<FindOne> orderByAddress = new Consumer<FindOne>() {
+          public void accept(FindOne t) {
+            t.orderBy("{address:1}");
+          }
+        };
+
+        collection.save(new Friend("John", "23 Wall Street Av."));
+        collection.save(new Friend("John", "21 Wall Street Av."));
+        collection.save(new Friend("John", "22 Wall Street Av."));
+
+        Friend friend = collection.findOne().with(orderByAddress).as(Friend.class);
 
         assertThat(friend.getAddress()).isEqualTo("21 Wall Street Av.");
     }

--- a/src/test/java/org/jongo/UpdateTest.java
+++ b/src/test/java/org/jongo/UpdateTest.java
@@ -19,6 +19,7 @@ package org.jongo;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteResult;
 import org.bson.types.ObjectId;
+import org.jongo.function.Consumer;
 import org.jongo.model.Friend;
 import org.jongo.util.JongoTestCase;
 import org.junit.After;
@@ -64,6 +65,25 @@ public class UpdateTest extends JongoTestCase {
 
         /* when */
         collection.update("{name:'John'}").multi().with("{$unset:{name:1}}");
+
+        /* then */
+        Iterable<Friend> friends = collection.find("{name:{$exists:true}}").as(Friend.class);
+        assertThat(friends).hasSize(0);
+    }
+
+    @Test
+    public void canUpdateWithOperators() throws Exception {
+        Consumer<Update> multi = new Consumer<Update>() {
+          public void accept(Update t) {
+            t.multi();
+          }
+        };
+        /* given */
+        collection.save(new Friend("John"));
+        collection.save(new Friend("John"));
+
+        /* when */
+        collection.update("{name:'John'}").with(multi).with("{$unset:{name:1}}");
 
         /* then */
         Iterable<Friend> friends = collection.find("{name:{$exists:true}}").as(Friend.class);


### PR DESCRIPTION
**DO NOT MERGE, WORK IN PROGRESS**  Please comment with feedback.

This PR adds some methods and interfaces to help code reuse and reduce instances where call chaining must be broken.  For instance, if you are building long aggregation pipelines, but there are some conditional steps in the middle, this change will help.

```
collection.aggregate("{...}")
  .and("{...}")
  .with(a->{
    if( test() ) {
      a.and("{...}")
    } else {
      a.and("{...}")
    }
  })
  .and("{...}")
  .as(Type.class);
```

Any thoughts on other ways the API could be improved for use with lambdas?
