### PR TITLE
Added skip duplicates functionality.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.jongo</groupId>
     <artifactId>jongo</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
     <name>Jongo</name>
     <description>Query in Java as in Mongo shell</description>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.jongo</groupId>
     <artifactId>jongo</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Jongo</name>
     <description>Query in Java as in Mongo shell</description>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,14 @@
     <description>Query in Java as in Mongo shell</description>
     <url>http://www.jongo.org</url>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>applangoart</id>
+            <name>applangoart-snapshots</name>
+            <url>http://localhost:8081/artifactory/ext-snapshot-local</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>

--- a/src/main/java/org/jongo/Insert.java
+++ b/src/main/java/org/jongo/Insert.java
@@ -67,7 +67,7 @@ class Insert {
             dbos.add(dbo);
         }
         InsertOptions io = new InsertOptions();
-        io = io.continueOnError(true).writeConcern(writeConcern).bypassDocumentValidation(true);
+        io = io.continueOnError(true).writeConcern(writeConcern);
         try {
             return collection.insert(dbos, io);
         } catch (DuplicateKeyException e) {

--- a/src/main/java/org/jongo/Insert.java
+++ b/src/main/java/org/jongo/Insert.java
@@ -59,6 +59,19 @@ class Insert {
         return collection.insert(dbos, writeConcern);
     }
 
+    public WriteResult insertSkipDuplicates(Object... pojos) {
+        List<DBObject> dbos = new ArrayList<DBObject>(pojos.length);
+        for (Object pojo : pojos) {
+            Object id = preparePojo(pojo);
+            DBObject dbo = convertToDBObject(pojo, id);
+            dbos.add(dbo);
+        }
+        InsertOptions io = new InsertOptions();
+        io = io.continueOnError(true).writeConcern(writeConcern);
+        return collection.insert(dbos,io);
+    }
+
+
     public WriteResult insert(String query, Object... parameters) {
         DBObject dbQuery = queryFactory.createQuery(query, parameters).toDBObject();
         if (dbQuery instanceof BasicDBList) {

--- a/src/main/java/org/jongo/Insert.java
+++ b/src/main/java/org/jongo/Insert.java
@@ -67,8 +67,12 @@ class Insert {
             dbos.add(dbo);
         }
         InsertOptions io = new InsertOptions();
-        io = io.continueOnError(true).writeConcern(writeConcern);
-        return collection.insert(dbos,io);
+        io = io.continueOnError(true).writeConcern(writeConcern).bypassDocumentValidation(true);
+        try {
+            return collection.insert(dbos, io);
+        } catch (DuplicateKeyException e) {
+            return WriteResult.unacknowledged();
+        }
     }
 
 

--- a/src/main/java/org/jongo/Jongo.java
+++ b/src/main/java/org/jongo/Jongo.java
@@ -63,4 +63,12 @@ public class Jongo {
     public Command runCommand(String query, Object... parameters) {
         return new Command(database, mapper.getUnmarshaller(), mapper.getQueryFactory(), query, parameters);
     }
+
+    public void requestStart() {
+        database.requestStart();
+    }
+
+    public void requestDone() {
+        database.requestDone();
+    }
 }

--- a/src/main/java/org/jongo/MongoCollection.java
+++ b/src/main/java/org/jongo/MongoCollection.java
@@ -140,6 +140,10 @@ public class MongoCollection {
         return new Insert(collection, writeConcern, mapper.getMarshaller(), mapper.getObjectIdUpdater(), mapper.getQueryFactory()).insert(pojos);
     }
 
+    public WriteResult insertSkipDuplicates(Object... pojos) {
+        return new Insert(collection, writeConcern, mapper.getMarshaller(), mapper.getObjectIdUpdater(), mapper.getQueryFactory()).insertSkipDuplicates(pojos);
+    }
+
     public WriteResult insert(String query, Object... parameters) {
         return new Insert(collection, writeConcern, mapper.getMarshaller(), mapper.getObjectIdUpdater(), mapper.getQueryFactory()).insert(query, parameters);
     }

--- a/src/test/java/org/jongo/InsertTest.java
+++ b/src/test/java/org/jongo/InsertTest.java
@@ -76,6 +76,20 @@ public class InsertTest extends JongoTestCase {
     }
 
     @Test
+    public void canInsertPojosSkipDuplicates() throws Exception {
+
+        Friend friend = new Friend("John");
+        Friend friend2 = new Friend("Robert");
+        Friend friend3 = new Friend("John"); //Again
+        collection.ensureIndex("{name:true}", "{unique:true}");
+        collection.insertSkipDuplicates(friend, friend2, friend3);
+
+        assertThat(collection.count("{name:'John'}")).isEqualTo(1);
+        assertThat(collection.count("{name:'Robert'}")).isEqualTo(1);
+    }
+
+
+    @Test
     public void canInsertWithParameters() throws Exception {
 
         collection.insert("{name : #}", "Abby");


### PR DESCRIPTION
Hi, 
There could be older commits in the history... they are overwritten with last merge of upstream v. 1.3.0
We are using mongo with bulk inserts of data that comes from external source. And faced  a problem that current jongo implementation doesn't provide any way to bulk insert skipping duplicates. So I've implemented that method adding an insert option. Maybe it could be done introducing some insertOption abstraction to the code, but we made a simple change that works. If you find it valuable feel free to merge into future versions of jongo.
Best,
Vasily.