### PR TITLE
added support de/serialization of javax.persistence.Id annotated classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,8 @@
         <mongo.version>3.5.0</mongo.version>
         <jackson.version>2.7.8</jackson.version>
         <bson4jackson.version>2.7.0</bson4jackson.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <logback.version>1.2.3</logback.version>
     </properties>
 
     <dependencies>
@@ -124,6 +126,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+        </dependency>
 
         <!-- TEST -->
         <dependency>
@@ -162,6 +169,31 @@
             <version>0.9.9-RC1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/org/jongo/marshall/jackson/JacksonObjectIdUpdater.java
+++ b/src/main/java/org/jongo/marshall/jackson/JacksonObjectIdUpdater.java
@@ -97,6 +97,7 @@ public class JacksonObjectIdUpdater implements ObjectIdUpdater {
     private static boolean isObjectId(BeanPropertyDefinition property) {
         return property.getPrimaryMember().getAnnotation(org.jongo.marshall.jackson.oid.ObjectId.class) != null
                 || property.getPrimaryMember().getAnnotation(MongoObjectId.class) != null
+                || property.getPrimaryMember().getAnnotation(javax.persistence.Id.class) != null
                 || ObjectId.class.isAssignableFrom(property.getAccessor().getRawType());
     }
 
@@ -107,7 +108,9 @@ public class JacksonObjectIdUpdater implements ObjectIdUpdater {
     private static boolean hasIdAnnotation(BeanPropertyDefinition property) {
         if (property == null) return false;
         AnnotatedMember accessor = property.getPrimaryMember();
-        return accessor != null && (accessor.getAnnotation(MongoId.class) != null || accessor.getAnnotation(Id.class) != null);
+        return accessor != null && (accessor.getAnnotation(MongoId.class) != null
+                || accessor.getAnnotation(Id.class) != null
+                || accessor.getAnnotation(javax.persistence.Id.class) != null);
     }
 
     private BasicBeanDescription beanDescription(Class<?> cls) {

--- a/src/main/java/org/jongo/marshall/jackson/JongoAnnotationIntrospector.java
+++ b/src/main/java/org/jongo/marshall/jackson/JongoAnnotationIntrospector.java
@@ -52,10 +52,10 @@ public class JongoAnnotationIntrospector extends NopAnnotationIntrospector {
     }
 
     private static boolean hasMongoId(Annotated a) {
-        return a.hasAnnotation(MongoId.class) || a.hasAnnotation(Id.class);
+        return a.hasAnnotation(MongoId.class) || a.hasAnnotation(Id.class) || a.hasAnnotation(javax.persistence.Id.class);
     }
 
     private static boolean hasMongoObjectId(Annotated a) {
-        return a.hasAnnotation(MongoObjectId.class) || a.hasAnnotation(ObjectId.class);
+        return a.hasAnnotation(MongoObjectId.class) || a.hasAnnotation(ObjectId.class) || a.hasAnnotation(javax.persistence.Id.class);
     }
 }

--- a/src/test/java/org/jongo/model/PersistenceFriend.java
+++ b/src/test/java/org/jongo/model/PersistenceFriend.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2011 Benoit GUEROUT <bguerout at gmail dot com> and Yves AMSELLEM <amsellem dot yves at gmail dot com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jongo.model;
+
+import javax.persistence.Id;
+
+public class PersistenceFriend {
+
+    @Id
+    private String id;
+    private String name;
+
+    private PersistenceFriend() {
+    }
+
+    public PersistenceFriend(String name) {
+        this.name = name;
+    }
+
+    public PersistenceFriend(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public static PersistenceFriend createFriendWithoutId(String name) {
+        PersistenceFriend friend = new PersistenceFriend();
+        friend.setName(name);
+        return friend;
+    }
+}

--- a/src/test/java/org/jongo/use_native/InsertNativeTest.java
+++ b/src/test/java/org/jongo/use_native/InsertNativeTest.java
@@ -23,6 +23,7 @@ import org.bson.types.ObjectId;
 import org.jongo.model.Coordinate;
 import org.jongo.model.ExposableFriend;
 import org.jongo.model.ExternalFriend;
+import org.jongo.model.PersistenceFriend;
 import org.jongo.model.Friend;
 import org.junit.After;
 import org.junit.Before;
@@ -73,6 +74,19 @@ public class InsertNativeTest extends NativeTestBase {
         Friend result = collection.find(id(oid)).first();
         assertThat(result.getId()).isEqualTo(oid);
         assertThat(john.getId().getDate().getTime()).isLessThan(afterSave);  //insert
+    }
+
+    @Test
+    public void canInsertWithPersistenceId() throws Exception {
+
+        MongoCollection<PersistenceFriend> friends = collection.withDocumentClass(PersistenceFriend.class);
+
+        String id = ObjectId.get().toString();
+        PersistenceFriend john = new PersistenceFriend(id, "Robert");
+        friends.insertOne(john);
+
+        PersistenceFriend result = friends.find().first();
+        assertThat(result.getId()).isEqualTo(id);
     }
 
     @Test

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+    </layout>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
Hi @bguerout, I added support for javax.persistence.Id to Jongo as I have a requirement to build model objects without dependencies on implementation libraries (i.e. Jongo). Any chance this could be merged and released?

2 changes:
* added abilility to de/serialize objects with `javax.persistence.Id`
* added missing slf4j dependencies for test execution