### PR TITLE
Add Closeable on ResultsIterator

### DIFF
--- a/src/main/java/org/jongo/Aggregate.java
+++ b/src/main/java/org/jongo/Aggregate.java
@@ -17,11 +17,14 @@
 package org.jongo;
 
 import com.mongodb.AggregationOptions;
+import com.mongodb.Cursor;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import org.jongo.marshall.Unmarshaller;
 import org.jongo.query.QueryFactory;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -72,7 +75,7 @@ public class Aggregate {
         return new ResultsIterator<T>(results, resultHandler);
     }
 
-    public static class ResultsIterator<E> implements Iterator<E>, Iterable<E> {
+    public static class ResultsIterator<E> implements Iterator<E>, Iterable<E>, Closeable {
 
         private Iterator<DBObject> results;
         private ResultHandler<E> resultHandler;
@@ -100,6 +103,17 @@ public class Aggregate {
 
         public void remove() {
             throw new UnsupportedOperationException("remove() method is not supported");
+        }
+
+        public void close() throws IOException {
+            if (results instanceof Closeable) {
+                Closeable closeable = (Closeable) results;
+                closeable.close();
+            }
+        }
+
+        boolean isCursor() {
+            return (results instanceof Cursor);
         }
     }
 }

--- a/src/test/java/org/jongo/AggregateTest.java
+++ b/src/test/java/org/jongo/AggregateTest.java
@@ -19,6 +19,7 @@ package org.jongo;
 import com.google.common.collect.Lists;
 import com.mongodb.AggregationOptions;
 import com.mongodb.MongoCommandException;
+import org.jongo.Aggregate.ResultsIterator;
 import org.jongo.model.Article;
 import org.jongo.model.Friend;
 import org.jongo.model.TypeWithNested;
@@ -28,14 +29,16 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Iterator;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static junit.framework.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class AggregateTest extends JongoTestBase {
 
@@ -43,10 +46,11 @@ public class AggregateTest extends JongoTestBase {
     private MongoCollection collection;
     private MongoCollection friendCollection;
     private MongoCollection nestedCollection;
+    private ResultsIterator<Article> articles;
 
     @Before
     public void setUp() throws Exception {
-
+        this.articles = null;
         assumeThatMongoVersionIsGreaterThan("2.6");
 
         collection = createEmptyCollection("articles");
@@ -73,12 +77,16 @@ public class AggregateTest extends JongoTestBase {
         dropCollection("external_type");
         dropCollection("friends");
         dropCollection("articles");
+
+        if (this.articles != null) {
+            this.articles.close();
+        }
     }
 
     @Test
-    public void canAggregate() throws Exception {
+    public void canAggregate() {
 
-        Iterable<Article> articles = collection.aggregate("{$match:{}}").as(Article.class);
+        articles = collection.aggregate("{$match:{}}").as(Article.class);
 
         assertThat(articles.iterator().hasNext()).isTrue();
         for (Article article : articles) {
@@ -87,22 +95,24 @@ public class AggregateTest extends JongoTestBase {
     }
 
     @Test
-    public void canAggregateWithDefaultOptions() throws Exception {
+    public void canAggregateWithDefaultOptions() {
         AggregationOptions options = AggregationOptions.builder().build();
-        Iterable<Article> articles = collection.aggregate("{$match:{}}").options(options).as(Article.class);
+        articles = collection.aggregate("{$match:{}}").options(options).as(Article.class);
 
         assertThat(articles.iterator().hasNext()).isTrue();
         for (Article article : articles) {
             assertThat(article.getTitle()).isIn("Zombie Panic", "Apocalypse Zombie", "World War Z");
         }
+
+        assertThat(articles.isCursor()).isTrue();
     }
 
     @Test
-    public void canAggregateWithOptions() throws Exception {
+    public void canAggregateWithOptions() {
 
         AggregationOptions options = spy(AggregationOptions.builder().outputMode(AggregationOptions.OutputMode.CURSOR).allowDiskUse(true).build());
 
-        Iterable<Article> articles = collection.aggregate("{$match:{}}").options(options).as(Article.class);
+        articles = collection.aggregate("{$match:{}}").options(options).as(Article.class);
 
         assertThat(articles.iterator().hasNext()).isTrue();
         for (Article article : articles) {
@@ -112,12 +122,13 @@ public class AggregateTest extends JongoTestBase {
         verify(options, atLeastOnce()).getMaxTime(any(TimeUnit.class));
         verify(options, atLeastOnce()).getBatchSize();
         verify(options, atLeastOnce()).getOutputMode();
+        assertThat(articles.isCursor()).isTrue();
     }
 
     @Test
-    public void canAggregateWithMultipleDocuments() throws Exception {
+    public void canAggregateWithMultipleDocuments() {
 
-        Iterable<Article> articles = collection.aggregate("{$match:{tags:'virus'}}").as(Article.class);
+        articles = collection.aggregate("{$match:{tags:'virus'}}").as(Article.class);
 
         assertThat(articles.iterator().hasNext()).isTrue();
         int size = 0;
@@ -129,18 +140,18 @@ public class AggregateTest extends JongoTestBase {
     }
 
     @Test
-    public void canAggregateParameters() throws Exception {
+    public void canAggregateParameters() {
 
-        Iterator<Article> articles = collection.aggregate("{$match:{tags:#}}", "pandemic").as(Article.class);
+        ResultsIterator<Article> articles = collection.aggregate("{$match:{tags:#}}", "pandemic").as(Article.class);
 
         assertThat(articles.next().getTitle()).isEqualTo("World War Z");
         assertThat(articles.hasNext()).isFalse();
     }
 
     @Test
-    public void canAggregateWithManyMatch() throws Exception {
+    public void canAggregateWithManyMatch() {
 
-        Iterator<Article> articles = collection.aggregate("{$match:{tags:'virus'}}").and("{$match:{tags:'pandemic'}}").as(Article.class);
+        articles = collection.aggregate("{$match:{tags:'virus'}}").and("{$match:{tags:'pandemic'}}").as(Article.class);
 
         Article firstArticle = articles.next();
         assertThat(firstArticle.getTitle()).isEqualTo("World War Z");
@@ -148,16 +159,16 @@ public class AggregateTest extends JongoTestBase {
     }
 
     @Test
-    public void canAggregateWithManyOperators() throws Exception {
+    public void canAggregateWithManyOperators() {
 
-        Iterator<Article> articles = collection.aggregate("{$match:{tags:'virus'}}").and("{$limit:1}").as(Article.class);
+        articles = collection.aggregate("{$match:{tags:'virus'}}").and("{$limit:1}").as(Article.class);
 
         articles.next();
         assertThat(articles.hasNext()).isFalse();
     }
 
     @Test
-    public void shouldCheckIfCommandHasErrors() throws Exception {
+    public void shouldCheckIfCommandHasErrors() {
 
         try {
             collection.aggregate("{$invalid:{}}").as(Article.class);
@@ -168,29 +179,35 @@ public class AggregateTest extends JongoTestBase {
     }
 
     @Test
-    public void shouldPopulateIds() throws Exception {
+    public void shouldPopulateIds() throws IOException {
+        ResultsIterator<Friend> resultsIterator = friendCollection.aggregate("{$project: {_id: '$_id', name: '$name'}}")
+                .as(Friend.class);
         List<Friend> friends = Lists.newArrayList(
-                (Iterable<Friend>) friendCollection.aggregate("{$project: {_id: '$_id', name: '$name'}}")
-                        .as(Friend.class));
+                (Iterable<Friend>) resultsIterator);
 
         assertThat(friends.isEmpty()).isEqualTo(false);
         for (Friend friend : friends) {
             assertThat(friend.getId()).isNotNull();
         }
+
+        resultsIterator.close();
     }
 
     @Test
-    public void shouldUnmarshalNestedDocuments() {
-        List<NestedDocument> nested = Lists.newArrayList((Iterable<NestedDocument>) nestedCollection
+    public void shouldUnmarshalNestedDocuments() throws IOException {
+        ResultsIterator<NestedDocument> resultsIterator = nestedCollection
                 .aggregate("{$unwind: '$nested'}")
                 .and("{$project: {name: '$nested.name', value: '$nested.value'}}")
-                .as(NestedDocument.class));
+                .as(NestedDocument.class);
+        List<NestedDocument> nested = Lists.newArrayList((Iterable<NestedDocument>) resultsIterator);
 
         assertThat(nested.isEmpty()).isEqualTo(false);
         assertThat(nested.get(0)).isEqualToComparingFieldByField(new NestedDocument().withName("name1").withValue("value1"));
         assertThat(nested.get(1)).isEqualToComparingFieldByField(new NestedDocument().withName("name2").withValue("value2"));
         assertThat(nested.get(2)).isEqualToComparingFieldByField(new NestedDocument().withName("name3").withValue("value3"));
         assertThat(nested.get(3)).isEqualToComparingFieldByField(new NestedDocument().withName("name4").withValue("value4"));
+
+        resultsIterator.close();
     }
 
 }


### PR DESCRIPTION
By default with the last mongo driver, the ResultsIterator will be a Cursor.
Moreaver the OutpuMode.CURSOR is deprecated in mongo java driver.