### PR TITLE
bump mongo-java-driver to 3.10.1 to be compatible with 3.6+ databases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mongo.min.version>3.3.0</mongo.min.version>
-        <mongo.max.version>3.5.0</mongo.max.version>
-        <mongo.version>3.5.0</mongo.version>
+        <mongo.min.version>3.5.0</mongo.min.version>
+        <mongo.max.version>3.11.0</mongo.max.version>
+        <mongo.version>3.10.1</mongo.version>
         <jackson.version>2.9.8</jackson.version>
         <bson4jackson.version>2.9.2</bson4jackson.version>
     </properties>

--- a/src/test/java/org/jongo/query/BsonQueryFactoryTest.java
+++ b/src/test/java/org/jongo/query/BsonQueryFactoryTest.java
@@ -277,7 +277,7 @@ public class BsonQueryFactoryTest {
 
         Query query = factory.createQuery("{ name.#: 'John'}", "first");
 
-        assertThat(query.toDBObject().toString()).isEqualTo("{ \"name.first\" : \"John\"}");
+        assertThat(query.toDBObject().toString()).isEqualTo("{\"name.first\": \"John\"}");
     }
 
     @Test

--- a/src/test/java/org/jongo/spike/projection/JacksonProjectionTest.java
+++ b/src/test/java/org/jongo/spike/projection/JacksonProjectionTest.java
@@ -42,7 +42,7 @@ public class JacksonProjectionTest {
 
         DBObject fields = projection.getProjectionQuery(Friend.class).toDBObject();
 
-        assertThat(fields.toString()).isEqualTo("{ \"name\" : 1 , \"address\" : 1 , \"coordinate\" : { \"lat\" : 1 , \"lng\" : 1} , \"gender\" : 1}");
+        assertThat(fields.toString()).isEqualTo("{\"name\": 1, \"address\": 1, \"coordinate\": {\"lat\": 1, \"lng\": 1}, \"gender\": 1}");
     }
 
     @Test
@@ -50,7 +50,7 @@ public class JacksonProjectionTest {
 
         DBObject fields = projection.getProjectionQuery(Fox.class).toDBObject();
 
-        assertThat(fields.toString()).isEqualTo("{ \"name\" : 1 , \"color\" : 1 , \"gender\" : 1}");
+        assertThat(fields.toString()).isEqualTo("{\"name\": 1, \"color\": 1, \"gender\": 1}");
     }
 
     @Test
@@ -58,7 +58,7 @@ public class JacksonProjectionTest {
 
         DBObject fields = projection.getProjectionQuery(HiddenCoordinate.class).toDBObject();
 
-        assertThat(fields.toString()).isEqualTo("{ \"lng\" : 1}");
+        assertThat(fields.toString()).isEqualTo("{\"lng\": 1}");
     }
 
     @Test(expected = RuntimeException.class)


### PR DESCRIPTION
Updated the mongo Java SDK as per #357. Test are running fine but some minor string rendering difference in `DBObject.toString()` had to be adjusted in tests.