### PR TITLE
[backport] Bump jackson.version from 2.9.8 to 2.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+jdk:
+  - openjdk8
+
 cache:
   directories:
   - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mongo.version>[3.3.0,3.10.1]</mongo.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.10.0</jackson.version>
         <bson4jackson.version>2.9.2</bson4jackson.version>
     </properties>
 


### PR DESCRIPTION
Bumps `jackson.version` from 2.9.8 to 2.10.0.

Updates `jackson-core` from 2.9.8 to 2.10.0
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.9.8...jackson-core-2.10.0)

Updates `jackson-databind` from 2.9.8 to 2.10.0
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-annotations` from 2.9.8 to 2.10.0
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)