### PR TITLE
Allow to apply skip and limit parameters on the cursor count operation

### DIFF
--- a/src/main/java/org/jongo/MongoCursor.java
+++ b/src/main/java/org/jongo/MongoCursor.java
@@ -59,6 +59,20 @@ public class MongoCursor<E> implements Iterator<E>, Iterable<E>, Closeable {
     }
 
     public int count() {
+        return count(false);
+    }
+
+    /**
+     * @param applySkipLimit if true the count will depend on the "skip" and "limit" parameters of the cursor according
+     *                       to <a href="https://www.mongodb.com/docs/v4.2/reference/method/cursor.count/index.html">
+     *                       the cursor.count() MongoDB documentation</a>
+     * @return the number of documents referenced by the cursor
+     */
+    public int count(boolean applySkipLimit) {
+        if (applySkipLimit) {
+            return cursor.size();
+        }
+
         return cursor.count();
     }
 }

--- a/src/test/java/org/jongo/FindTest.java
+++ b/src/test/java/org/jongo/FindTest.java
@@ -76,6 +76,40 @@ public class FindTest extends JongoTestBase {
     }
 
     @Test
+    public void canFindAndCountRespectingTheLimitParameters() throws Exception {
+
+        Friend friend1 = new Friend(new ObjectId(), "John");
+        Friend friend2 = new Friend(new ObjectId(), "John");
+        Friend friend3 = new Friend(new ObjectId(), "John");
+        collection.insert(friend1, friend2, friend3);
+        MongoCursor<Friend> friends = collection
+                .find("{name:'John'}")
+                .limit(2)
+                .as(Friend.class);
+
+        int nbResults = friends.count(true);
+
+        assertThat(nbResults).isEqualTo(2);
+    }
+
+    @Test
+    public void canFindAndCountRespectingTheSkipParameters() throws Exception {
+
+        Friend friend1 = new Friend(new ObjectId(), "John");
+        Friend friend2 = new Friend(new ObjectId(), "John");
+        Friend friend3 = new Friend(new ObjectId(), "John");
+        collection.insert(friend1, friend2, friend3);
+        MongoCursor<Friend> friends = collection
+                .find("{name:'John'}")
+                .skip(2)
+                .as(Friend.class);
+
+        int nbResults = friends.count(true);
+
+        assertThat(nbResults).isEqualTo(1);
+    }
+
+    @Test
     public void shouldFailWhenUnableToUnmarshallResult() throws Exception {
         /* given */
         collection.insert("{error: 'NotaDate'}");


### PR DESCRIPTION
I figured out that even when backed by an index, the count operation will still have to scan every matched index key when used with a query. This can lead to performance issues when counting on large collection (for pagination for example).

To mitigate these issues the MongoDB shell allow to pass a `applySkipLimit` boolean parameter to the `cursor.count()` method to apply the `skip` and `limit` parameters of the cursor to the count operation. This way the count will stop when reaching the limit (which is often fine for pagination, as we rarely need to scroll until the last pages).

The goal of this PR is to add this parameter to the `count` method of the `MongoCursor` class in order to reflect the contract of the MongoDB shell method.

cc @Dayde 